### PR TITLE
fix: deduplicate contrib repo discovery

### DIFF
--- a/src/organvm_engine/contrib/discover.py
+++ b/src/organvm_engine/contrib/discover.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import yaml
 
+from organvm_engine.organ_config import organ_org_dirs
 from organvm_engine.paths import workspace_root
 
 
@@ -63,8 +64,9 @@ def discover_contrib_repos(
     ws = Path(workspace) if workspace else workspace_root()
     repos: list[ContribRepo] = []
 
-    # Scan all directories for contrib repos
-    for org_dir in ws.iterdir():
+    # Scan only canonical organ directories (avoids hardlink mirrors)
+    for org_name in organ_org_dirs():
+        org_dir = ws / org_name
         if not org_dir.is_dir():
             continue
         for repo_dir in org_dir.iterdir():


### PR DESCRIPTION
## Summary
- `discover_contrib_repos()` scanned all workspace subdirectories blindly
- `organvm/` is a hardlinked mirror of `meta-organvm/` (same inode), causing every contrib repo to appear twice
- Fix: use `organ_org_dirs()` from `organ_config.py` to scan only canonical organ directories
- 48 repos → 24, 100 backflow signals → 50

## Test plan
- [x] `discover_contrib_repos()` returns 24 unique repos
- [x] `organvm contrib list` shows no duplicates
- [ ] `organvm contrib backflow --write` generates accurate signal counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)