### PR TITLE
fix(prompts): skip NULL-timestamp Paste.app rows in clipboard extractor (DONE-567)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ htmlcov/
 
 # Clipboard export data (contains personal clipboard history)
 src/organvm_engine/prompts/clipboard/data/
+ai-prompts-clipboard-export.json
+ai-prompts-clipboard-export.md
 
 # MCP tool working directories
 .serena/

--- a/src/organvm_engine/prompts/clipboard/extractor.py
+++ b/src/organvm_engine/prompts/clipboard/extractor.py
@@ -59,6 +59,7 @@ def load_items(db_path: Path | None = None) -> list[ClipboardItem]:
         LEFT JOIN ZAPPLICATIONENTITY a ON i.ZSOURCEAPPLICATION = a.Z_PK
         LEFT JOIN ZITEMDATAENTITY d ON d.ZITEM = i.Z_PK
         WHERE d.ZRAWPASTEBOARDITEMS IS NOT NULL
+          AND i.ZTIMESTAMP IS NOT NULL
         ORDER BY i.ZTIMESTAMP ASC
     """).fetchall()
     conn.close()


### PR DESCRIPTION
## What

A single Paste.app clipboard item with a `NULL` `ZTIMESTAMP` crashed the **entire** clipboard extraction:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
  at prompts/clipboard/extractor.py:71  →  datetime.fromtimestamp(ts + APPLE_EPOCH)
```

The SQL query filtered `WHERE d.ZRAWPASTEBOARDITEMS IS NOT NULL` but **not** on `i.ZTIMESTAMP`, so one poison row zeroed out all clipboard prompts.

## Fix

Add `AND i.ZTIMESTAMP IS NOT NULL` at the data-source boundary (matching the adjacent null-filter idiom). Rows we can't timestamp are unusable for the time-threaded narrative anyway. **Purely additive:** those rows previously produced *nothing* (crashed everything); now every valid row is recovered (1112 unique prompts extracted post-fix).

Also gitignore the CWD-default export artifacts (`ai-prompts-clipboard-export.*`), which contain personal clipboard history and must never be committed.

## Validation

- `organvm prompts clipboard` → rc=0, 1112 prompts extracted (previously crashed)
- 35 clipboard tests pass (`tests/test_clipboard_*.py`)

## Context

Surfaced by the `daily-operational-heartbeat` live-flip (DONE-566), whose `prompts-distill` routine drives `organvm prompts clipboard`. Related follow-up: **IRF-SYS-241** (align `clipboard`/`distill` default I/O paths + safe default output dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)