### PR TITLE
fix(session): thread --force through the archive CLI (IRF-SYS-243)

### DIFF
--- a/src/organvm_engine/cli/__init__.py
+++ b/src/organvm_engine/cli/__init__.py
@@ -1367,6 +1367,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Preview without writing",
     )
+    sess_archive.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-archive even if already archived (refresh a stale snapshot, "
+        "e.g. a resumed session whose work landed after an earlier archive)",
+    )
 
     sess_export = sess_sub.add_parser(
         "export",

--- a/src/organvm_engine/cli/session.py
+++ b/src/organvm_engine/cli/session.py
@@ -589,6 +589,7 @@ def cmd_session_archive(args: argparse.Namespace) -> int:
     agent = getattr(args, "agent", None)
     dry_run = getattr(args, "dry_run", False)
     no_raw = getattr(args, "no_raw", False)
+    force = getattr(args, "force", False)
 
     if session_id:
         # Archive a single session
@@ -601,6 +602,7 @@ def cmd_session_archive(args: argparse.Namespace) -> int:
             session_path,
             dry_run=dry_run,
             include_raw=not no_raw,
+            force=force,
         )
 
         if result.error:
@@ -624,6 +626,7 @@ def cmd_session_archive(args: argparse.Namespace) -> int:
         agent=agent,
         dry_run=dry_run,
         include_raw=not no_raw,
+        force=force,
     )
 
     if not results:

--- a/src/organvm_engine/session/archive.py
+++ b/src/organvm_engine/session/archive.py
@@ -291,11 +291,16 @@ def discover_unarchived_sessions(
     project_filter: str | None = None,
     since: str | None = None,
     agent: str | None = None,
+    force: bool = False,
 ) -> list[tuple[Path, SessionMeta]]:
     """Find sessions that have not yet been archived to their project repos.
 
     Returns list of (session_path, meta) tuples for unarchived sessions,
     sorted by date (newest first).
+
+    With ``force=True`` the already-archived filter is dropped, so every
+    session matching the filters is returned for re-archiving (refreshing a
+    stale snapshot of a resumed-then-continued session).
     """
     from organvm_engine.session.agents import discover_all_sessions
 
@@ -333,7 +338,7 @@ def discover_unarchived_sessions(
             seen_projects[project_key] = load_archive_state(project_path)
 
         state = seen_projects[project_key]
-        if meta.session_id not in state:
+        if force or meta.session_id not in state:
             unarchived.append((session_path, meta))
 
     return unarchived
@@ -346,6 +351,7 @@ def archive_all(
     agent: str | None = None,
     dry_run: bool = False,
     include_raw: bool = True,
+    force: bool = False,
 ) -> list[ArchiveResult]:
     """Archive all unprocessed sessions to their project directories.
 
@@ -355,6 +361,7 @@ def archive_all(
         agent: Only archive sessions from this agent (claude/gemini/codex).
         dry_run: Preview without writing.
         include_raw: Copy raw .jsonl files.
+        force: Re-archive sessions even if already archived (refresh stale snapshots).
 
     Returns:
         List of ArchiveResult for each session processed.
@@ -363,6 +370,7 @@ def archive_all(
         project_filter=project_filter,
         since=since,
         agent=agent,
+        force=force,
     )
 
     results: list[ArchiveResult] = []
@@ -371,6 +379,7 @@ def archive_all(
             session_path,
             dry_run=dry_run,
             include_raw=include_raw,
+            force=force,
         )
         results.append(result)
 

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -112,3 +112,61 @@ class TestArchiveState:
         _save_archive_state(tmp_path, state)
         loaded = load_archive_state(tmp_path)
         assert loaded["session-123"]["slug"] == "test"
+
+
+class TestForceReArchive:
+    """IRF-SYS-243: ``--force`` must bypass the skip-if-exists guard so a
+    resumed-then-continued session's stale archive can be refreshed. The
+    library always supported ``force``; the CLI never threaded it through."""
+
+    @staticmethod
+    def _make_claude_session(tmp_path: Path, session_id: str) -> Path:
+        """Write a minimal parseable Claude session JSONL rooted at tmp_path."""
+        jsonl = tmp_path / f"{session_id}.jsonl"
+        line = {
+            "type": "user",
+            "timestamp": "2026-05-30T10:00:00.000Z",
+            "cwd": str(tmp_path),
+            "gitBranch": "main",
+            "slug": "resumed-dancing-fox",
+            "message": {
+                "role": "user",
+                "content": "A sufficiently long human prompt so the session parses cleanly.",
+            },
+        }
+        jsonl.write_text(json.dumps(line) + "\n", encoding="utf-8")
+        return jsonl
+
+    def _seed_already_archived(self, tmp_path: Path, session_id: str) -> None:
+        from organvm_engine.session.archive import _save_archive_state
+
+        _save_archive_state(
+            tmp_path,
+            {session_id: {"slug": "stale", "archived_at": "2026-05-30T18:13:00+00:00"}},
+        )
+
+    def test_skips_already_archived_without_force(self, tmp_path: Path) -> None:
+        from organvm_engine.session.archive import archive_session
+
+        sid = "resumed-session-noforce"
+        jsonl = self._make_claude_session(tmp_path, sid)
+        self._seed_already_archived(tmp_path, sid)
+
+        result = archive_session(jsonl, dry_run=True)
+
+        assert result.skipped is True
+        assert "Already archived" in result.skip_reason
+
+    def test_force_re_archives_already_archived(self, tmp_path: Path) -> None:
+        from organvm_engine.session.archive import archive_session
+
+        sid = "resumed-session-force"
+        jsonl = self._make_claude_session(tmp_path, sid)
+        self._seed_already_archived(tmp_path, sid)
+
+        result = archive_session(jsonl, dry_run=True, force=True)
+
+        # force bypasses the skip guard — the session is re-processed.
+        assert result.skipped is False
+        assert result.error == ""
+        assert "transcript.md" in result.files_written


### PR DESCRIPTION
## Summary

Fixes **IRF-SYS-243**: `organvm session archive` could not refresh a stale archive from the CLI. `archive_session()` already accepted `force=False` to bypass the skip-if-exists guard, but the CLI never exposed or passed it — `cmd_session_archive` read only `session_id/project/since/agent/dry_run/no_raw`, and the subparser declared no `--force`. So a **resumed-then-continued** session whose work landed *after* an earlier archive could never be re-archived; the archived transcript froze pre-merge.

**Empirical motivation:** session `c1ab249a` archived 18:13 as `cuddly-swinging-alpaca`; PR #91 merged 18:55:37Z (`4ef8b97`) — 42 min later. The archived copy was permanently pre-merge with no supported refresh path.

## Change

Threads `force` through **both** code paths so the flag is never a silent no-op:

- `cli/__init__.py` — add `--force` to the `archive` subparser.
- `cli/session.py` — read `force`; pass into `archive_session()` (single) and `archive_all()` (batch).
- `session/archive.py` — `archive_all()` + `discover_unarchived_sessions()` gain `force`; discovery drops the already-archived filter when `force=True`.

**Backward-compatible:** default (no `--force`) still skips already-archived sessions.

## Verification

Behavioral, through the installed CLI (editable install = this branch):

```
$ organvm session archive --help        # now lists [--force]
$ organvm session archive c1ab249a --dry-run
Skipped: Already archived                # default unchanged
$ organvm session archive c1ab249a --force --dry-run
Would write: …/2026-05-29--cuddly-swinging-alpaca   # ← the bug's own victim, now refreshable
  transcript.md  prompts.md  review.md  meta.json  session.jsonl
```

- `pytest tests/test_session_archive.py` → 15 passed (incl. 2 new hermetic regression tests: skip vs force-bypass).
- Broader session suite (`test_session.py` + `test_session_review.py` + archive) → 73 passed.
- `pyright` on changed src → 0 errors.
- ⚠️ `ruff` could not be run locally (binary not installed in this env; only the Python shim). Changes match existing style/line-length; relying on CI for the ruff gate.

## Notes

- Distinct from **IRF-SYS-240** (the `session-auto-archive` *gate* coupling, G1/G3) — this is the `organvm session archive` *command's* skip-if-exists. Pairs with the Phase-2 SessionEnd-hook approach (archiving once at true session-end would make `--force` a rare-case affordance rather than the primary fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
