### PR TITLE
[limen LIMEN-068] fix(irf): stats command undercounts newly added tail items

### DIFF
--- a/src/organvm_engine/git/status.py
+++ b/src/organvm_engine/git/status.py
@@ -194,12 +194,12 @@ def diff_pinned(
 
 def check_uncommitted_files(workspace: Path | str | None = None) -> list[dict]:
     """Check for uncommitted files across all repos in the workspace.
-    
+
     Enforces the 'Nothing Local Only' covenant.
     """
     ws = Path(workspace) if workspace else DEFAULT_WORKSPACE
     uncommitted_reports = []
-    
+
     if not ws.exists():
         return uncommitted_reports
 
@@ -208,28 +208,28 @@ def check_uncommitted_files(workspace: Path | str | None = None) -> list[dict]:
         organ_path = ws / organ_dir
         if not (organ_path / ".git").exists():
             continue
-            
+
         result = _run_git(["submodule", "status"], organ_path)
         if result.returncode != 0:
             continue
-            
+
         for line in result.stdout.rstrip("\n").split("\n"):
             if not line.strip():
                 continue
             parts = line[1:].strip().split()
             if len(parts) < 2:
                 continue
-                
+
             repo_name = parts[1]
             repo_path = organ_path / repo_name
-            
+
             if not (repo_path / ".git").exists():
                 continue
-                
+
             status_result = _run_git(["status", "--porcelain"], repo_path)
             if status_result.returncode != 0:
                 continue
-                
+
             files = [line for line in status_result.stdout.strip().split("\n") if line.strip()]
             if files:
                 uncommitted_reports.append(
@@ -237,8 +237,8 @@ def check_uncommitted_files(workspace: Path | str | None = None) -> list[dict]:
                         "organ": organ_dir,
                         "repo": repo_name,
                         "uncommitted_count": len(files),
-                        "files": files[:5] + (["..."] if len(files) > 5 else [])
-                    }
+                        "files": files[:5] + (["..."] if len(files) > 5 else []),
+                    },
                 )
-                
+
     return uncommitted_reports

--- a/src/organvm_engine/irf/parser.py
+++ b/src/organvm_engine/irf/parser.py
@@ -44,10 +44,9 @@ class IRFItem:
 # Matches a ## section header (## or ###, not ####)
 _SECTION_RE = re.compile(r"^(#{2,3})\s+(.+)$")
 
-# Matches a pipe-delimited table row with at least 4 non-separator cells.
-# We accept rows like:  | cell | cell | cell | cell |
-# A trailing pipe is optional — hand-appended rows sometimes lack it.
-_ROW_RE = re.compile(r"^\|(.+?)\|?$")
+# Matches a pipe-delimited table row. Markdown permits either edge pipe to be
+# omitted, and hand-appended tail rows commonly use that compact form.
+_ROW_RE = re.compile(r"^\s*\|?.+?\|.*$")
 
 # A separator row contains only hyphens, pipes, colons, and spaces.
 _SEPARATOR_RE = re.compile(r"^[\|\-\:\s]+$")
@@ -64,7 +63,7 @@ _DONE_REF_RE = re.compile(r"^DONE-\d+[a-z]?$")
 
 def _cells(raw_row: str) -> list[str]:
     """Split a raw markdown table row into stripped cell strings."""
-    return [c.strip() for c in raw_row.strip("|").split("|")]
+    return [c.strip() for c in raw_row.strip().strip("|").split("|")]
 
 
 def _strip_cell_markup(value: str) -> str:
@@ -243,7 +242,7 @@ def parse_irf_diagnostics(path: Path) -> tuple[list[IRFItem], list[tuple[int, st
             continue
 
         # Skip separator rows
-        if _SEPARATOR_RE.match(line):
+        if _SEPARATOR_RE.fullmatch(line):
             continue
 
         cells = _cells(line)

--- a/src/organvm_engine/irf/writer.py
+++ b/src/organvm_engine/irf/writer.py
@@ -33,7 +33,10 @@ from organvm_engine.irf.parser import (
     parse_irf_diagnostics,
 )
 
-_ID_LINE_RE = re.compile(r"^\|\s*(?:\*\*|~~|`)*\s*(IRF-(?:[A-Z]+-)+\d+[a-z]?|DONE-\d+[a-z]?)\b")
+_ID_LINE_RE = re.compile(
+    r"^\s*\|?\s*(?:\*\*|~~|`)*\s*"
+    r"(IRF-(?:[A-Z]+-)+\d+[a-z]?|DONE-\d+[a-z]?)\b",
+)
 
 AUTOGEN_NOTE = (
     "<!-- AUTOGEN: regenerate via `organvm irf stats --write` — do not hand-edit"

--- a/tests/test_irf_cli.py
+++ b/tests/test_irf_cli.py
@@ -1,0 +1,34 @@
+"""Tests for the IRF CLI command handlers."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+from organvm_engine.cli.irf import cmd_irf_stats
+from organvm_engine.irf.parser import parse_irf
+
+FIXTURES = Path(__file__).parent / "fixtures"
+CASES = FIXTURES / "irf-parser-cases.md"
+
+
+def test_irf_stats_counts_tail_row_without_leading_pipe(tmp_path: Path, monkeypatch, capsys):
+    irf_path = tmp_path / "INST-INDEX-RERUM-FACIENDARUM.md"
+    irf_path.write_text(
+        CASES.read_text()
+        + "\n\n### S-tail Discovered Items (2026-06-18)\n\n"
+        + "ID | Priority | Action | Owner | Source | Blocker\n"
+        + "---|---|---|---|---|---\n"
+        + "IRF-TAIL-001 | P2 | Tail-created compact row | Agent | issue-71 | None\n",
+    )
+    monkeypatch.setenv("ORGANVM_CORPUS_DIR", str(tmp_path))
+
+    rc = cmd_irf_stats(Namespace(write=False, json=True))
+    captured = capsys.readouterr()
+    stats = json.loads(captured.out)
+
+    assert rc == 0
+    assert captured.err == ""
+    assert stats["total"] == len(parse_irf(CASES)) + 1
+    assert stats["by_domain"]["TAIL"] == 1

--- a/tests/test_irf_writer.py
+++ b/tests/test_irf_writer.py
@@ -88,6 +88,26 @@ def test_stats_count_short_tail_row_priority():
     assert stats["by_priority"]["P2"] == 2
 
 
+def test_tail_row_without_leading_pipe_parses_and_counts(tmp_path: Path):
+    """Tail-appended Markdown rows may omit the leading pipe; stats must see them."""
+    path = tmp_path / "irf.md"
+    path.write_text(
+        CASES.read_text()
+        + "\n\n### S-tail Discovered Items (2026-06-18)\n\n"
+        + "ID | Priority | Action | Owner | Source | Blocker\n"
+        + "---|---|---|---|---|---\n"
+        + "IRF-TAIL-001 | P2 | Tail-created compact row | Agent | issue-71 | None\n",
+    )
+
+    items, skipped = parse_irf_diagnostics(path)
+    stats = irf_stats(items)
+
+    assert skipped == []
+    assert stats["total"] == len(parse_irf(CASES)) + 1
+    assert stats["by_domain"]["TAIL"] == 1
+    assert next(i for i in items if i.id == "IRF-TAIL-001").priority == "P2"
+
+
 def test_late_file_row_resolves():
     """IRF-OPS-088 — rows late in the file are reachable."""
     assert "IRF-OPS-087" in _ids(CASES)
@@ -246,6 +266,17 @@ def test_stats_regeneration_is_idempotent(working_copy: Path):
     write_in_place(working_copy, first.new_text)
     second = regenerate_stats_block(working_copy, date="2026-06-07")
     assert second.new_text == first.new_text
+
+
+def test_stats_regeneration_guards_compact_tail_rows(working_copy: Path):
+    write_in_place(
+        working_copy,
+        working_copy.read_text()
+        + "\nIRF-TAIL-001 | P2 | Tail-created compact row | Agent | issue-71 | None\n",
+    )
+
+    with pytest.raises(IRFWriteError, match="ID-bearing"):
+        regenerate_stats_block(working_copy, date="2026-06-18")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-068`.

Audited 2026-06-01 from Jules-ready batch. fix(irf): stats command undercounts newly added tail items

Refs: https://github.com/a-organvm/organvm-engine/issues/71

_Produced in an isolated worktree off origin — review before merge._