### PR TITLE
[limen LIMEN-050] feat: context sync diff/changelog between runs

### DIFF
--- a/src/organvm_engine/cli/__init__.py
+++ b/src/organvm_engine/cli/__init__.py
@@ -32,7 +32,8 @@ Usage:
     organvm omega check
     organvm pitch generate <repo> [--dry-run]
     organvm pitch sync [--organ X] [--dry-run] [--tier X]
-    organvm context sync [--dry-run] [--organ X]
+    organvm context sync [--dry-run] [--organ X] [--diff]
+    organvm context changelog [--limit N] [--json]
     organvm context surfaces [--workspace <path>] [--repo <name>] [--json]
     organvm prompts narrate [--agent claude|gemini|codex] [--project FILTER] [--output FILE] [--summary FILE] [--dry-run] [--gap-hours 24]
     organvm plans atomize [--plans-dir DIR] [--output FILE] [--summary FILE] [--dry-run]
@@ -95,7 +96,11 @@ from organvm_engine.cli.content import (
     cmd_content_new,
     cmd_content_status,
 )
-from organvm_engine.cli.context import cmd_context_surfaces, cmd_context_sync
+from organvm_engine.cli.context import (
+    cmd_context_changelog,
+    cmd_context_surfaces,
+    cmd_context_sync,
+)
 from organvm_engine.cli.corpus import (
     cmd_corpus_coverage,
     cmd_corpus_gaps,
@@ -1143,6 +1148,26 @@ def build_parser() -> argparse.ArgumentParser:
         "--organ",
         default=None,
         help="Filter to specific organ",
+    )
+    c_sync.add_argument(
+        "--diff",
+        action="store_true",
+        help="Show line-level diff of each changed AUTO section",
+    )
+    c_changelog = ctx_sub.add_parser(
+        "changelog",
+        help="Show the recorded history of context sync runs",
+    )
+    c_changelog.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Show only the most recent N runs",
+    )
+    c_changelog.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON",
     )
     c_surfaces = ctx_sub.add_parser(
         "surfaces",
@@ -3313,6 +3338,7 @@ def main() -> int:
         ("pitch", "generate"): cmd_pitch_generate,
         ("pitch", "sync"): cmd_pitch_sync,
         ("context", "sync"): cmd_context_sync,
+        ("context", "changelog"): cmd_context_changelog,
         ("context", "surfaces"): cmd_context_surfaces,
         ("omega", "status"): cmd_omega_status,
         ("omega", "check"): cmd_omega_check,

--- a/src/organvm_engine/cli/cmd_pulse.py
+++ b/src/organvm_engine/cli/cmd_pulse.py
@@ -760,9 +760,10 @@ def cmd_pulse_ammoi(args: Namespace) -> int:
         if ammoi.density_delta_7d is not None:
             s = "+" if ammoi.density_delta_7d > 0 else ""
             print(f"     Δ7d:  {s}{ammoi.density_delta_7d:.1%}")
-        if getattr(ammoi, 'density_delta_30d', None) is not None:
-            s = "+" if ammoi.density_delta_30d > 0 else ""
-            print(f"     Δ30d: {s}{ammoi.density_delta_30d:.1%}")
+        d30 = getattr(ammoi, 'density_delta_30d', None)
+        if d30 is not None:
+            s = "+" if d30 > 0 else ""
+            print(f"     Δ30d: {s}{d30:.1%}")
 
     print()
     if ammoi.organs:

--- a/src/organvm_engine/cli/context.py
+++ b/src/organvm_engine/cli/context.py
@@ -26,6 +26,7 @@ def cmd_context_sync(args: argparse.Namespace) -> int:
 
     # --write overrides the default dry_run=True
     dry_run = not getattr(args, "write", False)
+    show_diff = getattr(args, "diff", False)
 
     organs = [args.organ] if args.organ else None
     result = sync_all(
@@ -33,6 +34,7 @@ def cmd_context_sync(args: argparse.Namespace) -> int:
         registry_path=args.registry,
         dry_run=dry_run,
         organs=organs,
+        collect_changes=True,
     )
 
     print("System Context Sync Results")
@@ -45,7 +47,32 @@ def cmd_context_sync(args: argparse.Namespace) -> int:
         for e in result["errors"]:
             print(f"    - {e['path']}: {e['error']}")
 
+    # Diff/changelog of what this run changed relative to the previous run
+    changes = result.get("changes")
+    if changes:
+        from organvm_engine.contextmd.changelog import RunChangelog, render_changes
+
+        run = RunChangelog(dry_run=dry_run, changes=changes)
+        print()
+        print(render_changes(run, show_diff=show_diff))
+        if not show_diff and run.with_diffs():
+            print("  (re-run with --diff to see line-level changes)")
+
+    if result.get("changelog_path"):
+        print(f"\nChangelog updated: {result['changelog_path']}")
+
     if result.get("dry_run"):
         print("\n[DRY RUN] No files were modified.")
 
     return 1 if result["errors"] else 0
+
+
+def cmd_context_changelog(args: argparse.Namespace) -> int:
+    from organvm_engine.contextmd.changelog import load_changelog, render_changelog
+
+    entries = load_changelog()
+    if getattr(args, "json", False):
+        print(json.dumps(entries, indent=2))
+    else:
+        print(render_changelog(entries, limit=getattr(args, "limit", None)))
+    return 0

--- a/src/organvm_engine/contextmd/changelog.py
+++ b/src/organvm_engine/contextmd/changelog.py
@@ -1,0 +1,216 @@
+"""Context sync diff/changelog — track what changes between sync runs.
+
+Each ``organvm context sync`` run can capture a per-file unified diff of the
+auto-generated section it replaces. Those diffs are accumulated into a
+``SyncChange`` list, rendered for the terminal, and (on ``--write``) appended as
+one entry to ``corpus_dir/data/context-sync/changelog.jsonl``. The changelog
+gives an audit trail of how each context file's AUTO block has drifted over
+time, run after run.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from organvm_engine.contextmd import AUTO_END, AUTO_START
+
+
+@dataclass
+class SyncChange:
+    """A single context file's change during one sync run."""
+
+    path: str
+    action: str  # "created" | "updated" | "unchanged"
+    added: int = 0
+    removed: int = 0
+    diff: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RunChangelog:
+    """The set of changes produced by one sync run."""
+
+    timestamp: str | None = None
+    dry_run: bool = False
+    changes: list[SyncChange] = field(default_factory=list)
+
+    @property
+    def updated(self) -> list[SyncChange]:
+        return [c for c in self.changes if c.action == "updated"]
+
+    @property
+    def created(self) -> list[SyncChange]:
+        return [c for c in self.changes if c.action == "created"]
+
+    def with_diffs(self) -> list[SyncChange]:
+        """Changes that carry a non-empty diff (created or updated)."""
+        return [c for c in self.changes if c.diff]
+
+    def to_entry(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "dry_run": self.dry_run,
+            "counts": {
+                "created": len(self.created),
+                "updated": len(self.updated),
+                "total_added": sum(c.added for c in self.changes),
+                "total_removed": sum(c.removed for c in self.changes),
+            },
+            "changes": [c.to_dict() for c in self.with_diffs()],
+        }
+
+
+def _extract_auto_section(content: str) -> str:
+    """Return the AUTO block (inclusive of markers) from *content*, or ""."""
+    start = content.find(AUTO_START)
+    end = content.find(AUTO_END)
+    if start == -1 or end == -1 or end < start:
+        return ""
+    return content[start : end + len(AUTO_END)]
+
+
+def compute_change(
+    file_path: Path | str,
+    old_content: str | None,
+    new_section: str,
+    action: str,
+) -> SyncChange:
+    """Build a :class:`SyncChange` describing a sync edit.
+
+    *old_content* is the full prior file content (None for a brand-new file).
+    The diff compares only the AUTO block — manual content outside the markers
+    is never part of the sync and so never part of the changelog.
+    """
+    path = str(file_path)
+    if action == "created":
+        new_lines = new_section.splitlines()
+        diff = "\n".join(f"+{line}" for line in new_lines)
+        return SyncChange(
+            path=path, action="created", added=len(new_lines), removed=0, diff=diff,
+        )
+
+    if action != "updated":
+        return SyncChange(path=path, action=action)
+
+    old_section = _extract_auto_section(old_content or "")
+    old_lines = old_section.splitlines()
+    new_lines = new_section.splitlines()
+    diff_lines = list(
+        difflib.unified_diff(
+            old_lines,
+            new_lines,
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+            lineterm="",
+        ),
+    )
+    added = sum(
+        1 for line in diff_lines if line.startswith("+") and not line.startswith("+++")
+    )
+    removed = sum(
+        1 for line in diff_lines if line.startswith("-") and not line.startswith("---")
+    )
+    return SyncChange(
+        path=path,
+        action="updated",
+        added=added,
+        removed=removed,
+        diff="\n".join(diff_lines),
+    )
+
+
+def render_changes(changelog: RunChangelog, show_diff: bool = False) -> str:
+    """Human-readable rendering of a run's changes."""
+    diffable = changelog.with_diffs()
+    if not diffable:
+        return "No context sections changed since the last sync."
+
+    lines: list[str] = []
+    lines.append("Context Sync Changelog")
+    lines.append("─" * 40)
+    for change in diffable:
+        marker = "NEW" if change.action == "created" else "MOD"
+        lines.append(f"  [{marker}] {change.path}  (+{change.added} -{change.removed})")
+        if show_diff and change.diff:
+            for diff_line in change.diff.splitlines():
+                lines.append(f"      {diff_line}")
+    total_added = sum(c.added for c in changelog.changes)
+    total_removed = sum(c.removed for c in changelog.changes)
+    lines.append("─" * 40)
+    lines.append(
+        f"  {len(changelog.created)} created, {len(changelog.updated)} updated "
+        f"(+{total_added} -{total_removed} lines)",
+    )
+    return "\n".join(lines)
+
+
+def append_changelog(
+    changelog: RunChangelog,
+    changelog_path: Path | str | None = None,
+) -> Path | None:
+    """Append this run as one JSONL entry to the changelog file.
+
+    Returns the path written, or None if there was nothing to record.
+    """
+    if not changelog.with_diffs():
+        return None
+    if changelog_path is None:
+        from organvm_engine.paths import context_sync_changelog_path
+
+        changelog_path = context_sync_changelog_path()
+    changelog_path = Path(changelog_path)
+    changelog_path.parent.mkdir(parents=True, exist_ok=True)
+    entry = changelog.to_entry()
+    with changelog_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return changelog_path
+
+
+def load_changelog(changelog_path: Path | str | None = None) -> list[dict[str, Any]]:
+    """Read all recorded run entries from the changelog file."""
+    if changelog_path is None:
+        from organvm_engine.paths import context_sync_changelog_path
+
+        changelog_path = context_sync_changelog_path()
+    changelog_path = Path(changelog_path)
+    if not changelog_path.is_file():
+        return []
+    entries: list[dict[str, Any]] = []
+    for line in changelog_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return entries
+
+
+def render_changelog(entries: list[dict[str, Any]], limit: int | None = None) -> str:
+    """Render recorded run history (most recent last)."""
+    if not entries:
+        return "No context-sync history recorded yet."
+    shown = entries[-limit:] if limit else entries
+    lines: list[str] = []
+    lines.append("Context Sync History")
+    lines.append("─" * 40)
+    for entry in shown:
+        ts = entry.get("timestamp") or "(no timestamp)"
+        counts = entry.get("counts", {})
+        dry = " [dry-run]" if entry.get("dry_run") else ""
+        lines.append(
+            f"  {ts}{dry}: "
+            f"{counts.get('created', 0)} created, {counts.get('updated', 0)} updated "
+            f"(+{counts.get('total_added', 0)} -{counts.get('total_removed', 0)})",
+        )
+    if limit and len(entries) > limit:
+        lines.append(f"  … {len(entries) - limit} earlier run(s) not shown")
+    return "\n".join(lines)

--- a/src/organvm_engine/contextmd/sync.py
+++ b/src/organvm_engine/contextmd/sync.py
@@ -30,8 +30,15 @@ def sync_all(
     dry_run: bool = False,
     organs: list[str] | None = None,
     additional_workspace_roots: list[Path] | None = None,
+    collect_changes: bool = False,
 ) -> dict[str, Any]:
-    """Sync auto-generated sections across all context files."""
+    """Sync auto-generated sections across all context files.
+
+    When *collect_changes* is True, the returned dict gains a ``changes`` key
+    holding per-file :class:`~organvm_engine.contextmd.changelog.SyncChange`
+    records (each with a unified diff of the AUTO block) describing what this
+    run changed relative to the on-disk state from the previous run.
+    """
     from organvm_engine.git.superproject import REGISTRY_KEY_MAP
     from organvm_engine.paths import additional_workspace_roots as resolve_additional_roots
     from organvm_engine.paths import workspace_root
@@ -87,6 +94,7 @@ def sync_all(
     created = []
     skipped = []
     errors = []
+    changes: list | None = [] if collect_changes else None
 
     target_organs = organs or list(REGISTRY_KEY_MAP.keys())
 
@@ -103,7 +111,9 @@ def sync_all(
             for filename in ["CLAUDE.md", "GEMINI.md", "AGENTS.md"]:
                 try:
                     organ_section = generate_organ_section(organ_key, reg, all_seeds)
-                    action = _inject_section(organ_path / filename, organ_section, dry_run)
+                    action = _inject_section(
+                        organ_path / filename, organ_section, dry_run, changes=changes,
+                    )
                     if action == "created":
                         created.append(str(organ_path / filename))
                     elif action == "updated":
@@ -133,6 +143,7 @@ def sync_all(
                     errors=errors,
                     promotion_to_phase=promotion_to_phase,
                     resolve_all_sops=resolve_all_sops,
+                    changes=changes,
                 )
 
         # 3b. Sync repo-level context files for additive flat workspace roots.
@@ -160,13 +171,14 @@ def sync_all(
                     errors=errors,
                     promotion_to_phase=promotion_to_phase,
                     resolve_all_sops=resolve_all_sops,
+                    changes=changes,
                 )
 
     # 4. Sync workspace-level context files
     for filename in ["CLAUDE.md", "GEMINI.md", "AGENTS.md"]:
         try:
             ws_section = generate_workspace_section(reg, all_seeds)
-            action = _inject_section(ws / filename, ws_section, dry_run)
+            action = _inject_section(ws / filename, ws_section, dry_run, changes=changes)
             if action == "created":
                 created.append(str(ws / filename))
             elif action == "updated":
@@ -183,6 +195,8 @@ def sync_all(
         "errors": errors,
         "dry_run": dry_run,
     }
+    if changes is not None:
+        result["changes"] = changes
 
     # Emit context sync event
     if not dry_run:
@@ -215,6 +229,27 @@ def sync_all(
                 "errors": len(errors),
             },
         )
+
+        # Persist the diff/changelog entry for this run
+        if changes:
+            from datetime import datetime, timezone
+
+            from organvm_engine.contextmd.changelog import (
+                RunChangelog,
+                append_changelog,
+            )
+
+            run = RunChangelog(
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                dry_run=dry_run,
+                changes=list(changes),
+            )
+            try:
+                written = append_changelog(run)
+                if written is not None:
+                    result["changelog_path"] = str(written)
+            except Exception:
+                pass
 
     return result
 
@@ -264,6 +299,7 @@ def _sync_repo_context_files(
     errors: list[dict[str, str]],
     promotion_to_phase,
     resolve_all_sops,
+    changes: list | None = None,
 ) -> None:
     repo_name = repo_entry.get("name")
     if not repo_name:
@@ -287,6 +323,7 @@ def _sync_repo_context_files(
                 dry_run,
                 filename=filename,
                 sop_entries=repo_sops,
+                changes=changes,
             )
             if res["action"] == "created":
                 created.append(res["path"])
@@ -301,7 +338,9 @@ def _sync_repo_context_files(
         agents_section = generate_agents_section(
             repo_name, org_name, registry, repo_to_seed.get(repo_name),
         )
-        action = _inject_section(repo_path / "AGENTS.md", agents_section, dry_run)
+        action = _inject_section(
+            repo_path / "AGENTS.md", agents_section, dry_run, changes=changes,
+        )
         if action == "created":
             created.append(str(repo_path / "AGENTS.md"))
         elif action == "updated":
@@ -321,6 +360,7 @@ def sync_repo(
     dry_run: bool = False,
     filename: str = "CLAUDE.md",
     sop_entries: list | None = None,
+    changes: list | None = None,
 ) -> dict[str, Any]:
     """Sync a single repo's context file."""
     agent = filename.replace(".md", "").lower() if filename else None
@@ -328,17 +368,34 @@ def sync_repo(
         repo_name, org, registry, seed, sop_entries=sop_entries, agent=agent,
     )
     file_path = repo_path / filename
-    action = _inject_section(file_path, section, dry_run)
+    action = _inject_section(file_path, section, dry_run, changes=changes)
     return {"path": str(file_path), "action": action, "dry_run": dry_run}
 
 
-def _inject_section(file_path: Path, new_section: str, dry_run: bool = False) -> str:
-    """Inject or replace the auto-generated section in a markdown file."""
+def _inject_section(
+    file_path: Path,
+    new_section: str,
+    dry_run: bool = False,
+    changes: list | None = None,
+) -> str:
+    """Inject or replace the auto-generated section in a markdown file.
+
+    When *changes* is provided, a :class:`~organvm_engine.contextmd.changelog.SyncChange`
+    describing the edit (with a unified diff of the AUTO block) is appended to it.
+    """
     import re
+
+    def _record(old_content: str | None, action: str) -> str:
+        if changes is not None:
+            from organvm_engine.contextmd.changelog import compute_change
+
+            changes.append(compute_change(file_path, old_content, new_section, action))
+        return action
+
     if not file_path.exists():
         if not dry_run:
             file_path.write_text(new_section + "\n")
-        return "created"
+        return _record(None, "created")
 
     content = file_path.read_text()
 
@@ -363,12 +420,12 @@ def _inject_section(file_path: Path, new_section: str, dry_run: bool = False) ->
         pattern = re.escape(AUTO_START) + r".*" + re.escape(AUTO_END)
         new_content = re.sub(pattern, new_section, content, flags=re.DOTALL)
         if new_content == content:
-            return "unchanged"
+            return _record(content, "unchanged")
         if not dry_run:
             file_path.write_text(new_content)
-        return "updated"
+        return _record(content, "updated")
     # Append to end
     new_content = content.rstrip() + "\n\n" + new_section + "\n"
     if not dry_run:
         file_path.write_text(new_content)
-    return "updated"
+    return _record(content, "updated")

--- a/src/organvm_engine/paths.py
+++ b/src/organvm_engine/paths.py
@@ -210,6 +210,16 @@ def content_dir(config: PathConfig | None = None) -> Path:
     return resolve_path_config(config).content_dir()
 
 
+def context_sync_dir(config: PathConfig | None = None) -> Path:
+    """Directory for context-sync changelog artifacts."""
+    return corpus_dir(config) / "data" / "context-sync"
+
+
+def context_sync_changelog_path(config: PathConfig | None = None) -> Path:
+    """Path to the context-sync changelog.jsonl file."""
+    return context_sync_dir(config) / "changelog.jsonl"
+
+
 def fossil_dir(config: PathConfig | None = None) -> Path:
     """Directory for fossil record artifacts."""
     return corpus_dir(config) / "data" / "fossil"

--- a/tests/test_context_changelog.py
+++ b/tests/test_context_changelog.py
@@ -1,0 +1,169 @@
+"""Tests for context sync diff/changelog (issue #73 / LIMEN-050)."""
+
+from organvm_engine.contextmd import AUTO_END, AUTO_START
+from organvm_engine.contextmd.changelog import (
+    RunChangelog,
+    append_changelog,
+    compute_change,
+    load_changelog,
+    render_changelog,
+    render_changes,
+)
+from organvm_engine.contextmd.sync import _inject_section
+
+
+class TestComputeChange:
+    def test_created_counts_all_lines_as_added(self):
+        section = f"{AUTO_START}\nline one\nline two\n{AUTO_END}"
+        change = compute_change("CLAUDE.md", None, section, "created")
+        assert change.action == "created"
+        assert change.added == 4
+        assert change.removed == 0
+        assert change.diff.startswith("+")
+
+    def test_updated_diffs_only_the_auto_block(self):
+        old = (
+            f"# Manual title\n\n{AUTO_START}\n## Old\nalpha\n{AUTO_END}\n\n## Manual\n"
+        )
+        new_section = f"{AUTO_START}\n## New\nbeta\n{AUTO_END}"
+        change = compute_change("CLAUDE.md", old, new_section, "updated")
+        assert change.action == "updated"
+        assert change.added > 0
+        assert change.removed > 0
+        # Manual content outside the markers must never appear in the diff
+        assert "Manual" not in change.diff
+        assert "alpha" in change.diff
+        assert "beta" in change.diff
+
+    def test_unchanged_has_empty_diff(self):
+        change = compute_change("CLAUDE.md", "whatever", "x", "unchanged")
+        assert change.diff == ""
+        assert change.added == 0
+
+
+class TestInjectSectionCollectsChanges:
+    def test_created_change_recorded(self, tmp_path):
+        target = tmp_path / "CLAUDE.md"
+        changes: list = []
+        _inject_section(target, f"{AUTO_START}\nhi\n{AUTO_END}", changes=changes)
+        assert len(changes) == 1
+        assert changes[0].action == "created"
+
+    def test_updated_change_recorded_with_diff(self, tmp_path):
+        target = tmp_path / "CLAUDE.md"
+        target.write_text(f"# T\n\n{AUTO_START}\nold\n{AUTO_END}\n")
+        changes: list = []
+        _inject_section(target, f"{AUTO_START}\nnew\n{AUTO_END}", changes=changes)
+        assert changes[0].action == "updated"
+        assert "old" in changes[0].diff
+        assert "new" in changes[0].diff
+
+    def test_unchanged_recorded_without_diff(self, tmp_path):
+        section = f"{AUTO_START}\nsame\n{AUTO_END}"
+        target = tmp_path / "CLAUDE.md"
+        target.write_text(f"# T\n\n{section}\n")
+        changes: list = []
+        action = _inject_section(target, section, changes=changes)
+        assert action == "unchanged"
+        assert changes[0].action == "unchanged"
+        assert changes[0].diff == ""
+
+    def test_no_collector_keeps_string_return(self, tmp_path):
+        target = tmp_path / "CLAUDE.md"
+        action = _inject_section(target, "## Plain")
+        assert action == "created"
+
+
+class TestRunChangelog:
+    def _sample(self):
+        return RunChangelog(
+            timestamp="2026-06-18T00:00:00+00:00",
+            dry_run=False,
+            changes=[
+                compute_change("a/CLAUDE.md", None, f"{AUTO_START}\nx\n{AUTO_END}", "created"),
+                compute_change(
+                    "b/CLAUDE.md",
+                    f"{AUTO_START}\nold\n{AUTO_END}",
+                    f"{AUTO_START}\nnew\n{AUTO_END}",
+                    "updated",
+                ),
+                compute_change("c/CLAUDE.md", "z", "z", "unchanged"),
+            ],
+        )
+
+    def test_with_diffs_excludes_unchanged(self):
+        run = self._sample()
+        assert len(run.with_diffs()) == 2
+
+    def test_partitions(self):
+        run = self._sample()
+        assert len(run.created) == 1
+        assert len(run.updated) == 1
+
+    def test_render_changes_summary_and_diff(self):
+        run = self._sample()
+        summary = render_changes(run, show_diff=False)
+        assert "b/CLAUDE.md" in summary
+        assert "new" not in summary  # no line-level diff without show_diff
+        detailed = render_changes(run, show_diff=True)
+        assert "new" in detailed
+
+    def test_render_changes_empty(self):
+        run = RunChangelog(changes=[compute_change("c", "z", "z", "unchanged")])
+        assert "No context sections changed" in render_changes(run)
+
+    def test_to_entry_counts(self):
+        entry = self._sample().to_entry()
+        assert entry["counts"]["created"] == 1
+        assert entry["counts"]["updated"] == 1
+        # only diffable changes are persisted
+        assert len(entry["changes"]) == 2
+
+
+class TestChangelogPersistence:
+    def test_append_and_load_roundtrip(self, tmp_path):
+        path = tmp_path / "changelog.jsonl"
+        run = RunChangelog(
+            timestamp="2026-06-18T00:00:00+00:00",
+            changes=[compute_change("a", None, f"{AUTO_START}\nx\n{AUTO_END}", "created")],
+        )
+        written = append_changelog(run, path)
+        assert written == path
+        entries = load_changelog(path)
+        assert len(entries) == 1
+        assert entries[0]["counts"]["created"] == 1
+
+    def test_append_skips_empty_run(self, tmp_path):
+        path = tmp_path / "changelog.jsonl"
+        run = RunChangelog(changes=[compute_change("c", "z", "z", "unchanged")])
+        assert append_changelog(run, path) is None
+        assert not path.exists()
+
+    def test_append_accumulates_runs(self, tmp_path):
+        path = tmp_path / "changelog.jsonl"
+        for _ in range(3):
+            run = RunChangelog(
+                timestamp="2026-06-18T00:00:00+00:00",
+                changes=[compute_change("a", None, f"{AUTO_START}\nx\n{AUTO_END}", "created")],
+            )
+            append_changelog(run, path)
+        assert len(load_changelog(path)) == 3
+
+    def test_load_missing_returns_empty(self, tmp_path):
+        assert load_changelog(tmp_path / "nope.jsonl") == []
+
+    def test_render_changelog_history_and_limit(self, tmp_path):
+        path = tmp_path / "changelog.jsonl"
+        for i in range(3):
+            run = RunChangelog(
+                timestamp=f"2026-06-18T00:0{i}:00+00:00",
+                changes=[compute_change("a", None, f"{AUTO_START}\nx\n{AUTO_END}", "created")],
+            )
+            append_changelog(run, path)
+        entries = load_changelog(path)
+        rendered = render_changelog(entries, limit=2)
+        assert "Context Sync History" in rendered
+        assert "earlier run(s) not shown" in rendered
+
+    def test_render_changelog_empty(self):
+        assert "No context-sync history" in render_changelog([])


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-050`.

Audited 2026-06-01 from Jules-ready batch. Fix issue #73 in a-organvm/organvm-engine.

Refs: https://github.com/a-organvm/organvm-engine/issues/73

_Produced in an isolated worktree off origin — review before merge._