### PR TITLE
[limen LIMEN-078] feat: formalize Score→Rehearse→Perform ritual in Conductor lifecycle

### DIFF
--- a/src/organvm_engine/cli/cmd_pulse.py
+++ b/src/organvm_engine/cli/cmd_pulse.py
@@ -760,7 +760,7 @@ def cmd_pulse_ammoi(args: Namespace) -> int:
         if ammoi.density_delta_7d is not None:
             s = "+" if ammoi.density_delta_7d > 0 else ""
             print(f"     Δ7d:  {s}{ammoi.density_delta_7d:.1%}")
-        if getattr(ammoi, 'density_delta_30d', None) is not None:
+        if ammoi.density_delta_30d is not None:
             s = "+" if ammoi.density_delta_30d > 0 else ""
             print(f"     Δ30d: {s}{ammoi.density_delta_30d:.1%}")
 

--- a/src/organvm_engine/coordination/__init__.py
+++ b/src/organvm_engine/coordination/__init__.py
@@ -6,10 +6,23 @@ and tool checkout line (SPEC-014).
 """
 
 from organvm_engine.coordination.lifecycle import (  # noqa: F401
+    CONDUCTOR_PHASE_ORDER,
+    CONDUCTOR_PHASE_RITUAL,
+    CONDUCTOR_PHASE_TRANSITIONS,
+    CONDUCTOR_RITUAL_GATES,
+    CONDUCTOR_RITUAL_SEQUENCE,
     PHASE_ORDER,
     PHASE_TRANSITIONS,
     WEIGHT_COSTS,
     AgentPhase,
+    ConductorPhase,
+    ConductorRitualGate,
+    ConductorRitualStage,
     ResourceWeight,
+    build_conductor_ritual_metadata,
+    conductor_ritual_contract,
+    conductor_ritual_stage,
+    normalise_conductor_phase,
+    valid_conductor_transition,
     valid_transition,
 )

--- a/src/organvm_engine/coordination/claims.py
+++ b/src/organvm_engine/coordination/claims.py
@@ -32,6 +32,7 @@ from organvm_engine.coordination.lifecycle import (
     WEIGHT_COSTS,  # noqa: F401 — re-exported for backward compat
     AgentPhase,  # noqa: F401 — re-exported for backward compat
     ResourceWeight,  # noqa: F401 — re-exported for backward compat
+    build_conductor_ritual_metadata,
     normalise_weight,
     weight_cost,
 )
@@ -123,6 +124,10 @@ class WorkClaim:
     scope: str = ""  # free-text description
     resource_weight: str = "medium"  # light, medium, heavy
     test_obligations: list[str] = field(default_factory=list)  # deferred test cmds
+    conductor_phase: str = "BUILD"
+    appetite_minutes: int | None = None
+    micro_spec: dict[str, Any] = field(default_factory=dict)
+    conductor_ritual: dict[str, Any] = field(default_factory=dict)
     ttl_seconds: int = DEFAULT_CLAIM_TTL_SECONDS
     released: bool = False
     release_timestamp: float = 0.0
@@ -154,6 +159,17 @@ class WorkClaim:
             parts.append(f"module:{m}")
         return parts
 
+    def ritual_metadata(self) -> dict[str, Any]:
+        """Return serialized Conductor ritual metadata for this claim."""
+        if self.conductor_ritual:
+            return self.conductor_ritual
+        return build_conductor_ritual_metadata(
+            phase=self.conductor_phase or "BUILD",
+            appetite_minutes=self.appetite_minutes,
+            micro_spec=self.micro_spec,
+            test_obligations=self.test_obligations,
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "claim_id": self.claim_id,
@@ -169,6 +185,10 @@ class WorkClaim:
             "resource_weight": self.resource_weight,
             "cost": self.cost,
             "test_obligations": self.test_obligations,
+            "conductor_phase": self.conductor_phase,
+            "appetite_minutes": self.appetite_minutes,
+            "micro_spec": self.micro_spec,
+            "conductor_ritual": self.ritual_metadata(),
             "ttl_seconds": self.ttl_seconds,
             "released": self.released,
             "release_timestamp": self.release_timestamp,
@@ -305,6 +325,9 @@ def punch_in(
     scope: str = "",
     resource_weight: str = "medium",
     test_obligations: list[str] | None = None,
+    conductor_phase: str = "BUILD",
+    appetite_minutes: int | None = None,
+    micro_spec: dict[str, Any] | None = None,
     ttl_seconds: int = DEFAULT_CLAIM_TTL_SECONDS,
 ) -> dict[str, Any]:
     """Punch in: declare areas of influence for this work session.
@@ -317,6 +340,10 @@ def punch_in(
         resource_weight: light (1), medium (2), or heavy (3) cost units.
         test_obligations: Test commands to defer to the prover session
             (e.g. ["pytest organvm-engine/tests/ -v"]).
+        conductor_phase: Current Conductor phase for this claim.
+        appetite_minutes: Score-phase appetite, when known.
+        micro_spec: Score-phase micro-spec with outcome, non_goals, and
+            acceptance_checks.
         ttl_seconds: Claim expiry (default 4h).
 
     Returns a dict with:
@@ -336,8 +363,15 @@ def punch_in(
     files = files or []
     modules = modules or []
     test_obligations = test_obligations or []
+    micro_spec = micro_spec or {}
 
     resource_weight = normalise_weight(resource_weight)
+    conductor_ritual = build_conductor_ritual_metadata(
+        phase=conductor_phase,
+        appetite_minutes=appetite_minutes,
+        micro_spec=micro_spec,
+        test_obligations=test_obligations,
+    )
 
     # Generate a unique handle (name tag)
     existing_handles = {c.handle for c in active_claims() if c.handle}
@@ -377,6 +411,10 @@ def punch_in(
         "scope": scope,
         "resource_weight": resource_weight,
         "test_obligations": test_obligations,
+        "conductor_phase": conductor_phase,
+        "appetite_minutes": appetite_minutes,
+        "micro_spec": micro_spec,
+        "conductor_ritual": conductor_ritual,
         "ttl_seconds": ttl_seconds,
     }
     _append_event(event)
@@ -399,6 +437,7 @@ def punch_in(
         "active_claims": len(active_claims()),
         "resource_weight": resource_weight,
         "cost": proposed_cost,
+        "conductor_ritual": conductor_ritual,
         "capacity": capacity_status(),
         "areas": [
             *[f"organ:{o}" for o in organs],
@@ -423,6 +462,7 @@ def punch_in(
                 "agent": agent,
                 "resource_weight": resource_weight,
                 "areas": result["areas"],
+                "conductor_ritual_stage": conductor_ritual["conductor_ritual_stage"],
             },
         )
     except Exception:
@@ -435,7 +475,12 @@ def punch_in(
         source_organ="META-ORGANVM",
         source_repo="organvm-engine",
         actor=handle,
-        payload={"agent": agent, "handle": handle, "areas": result["areas"]},
+        payload={
+            "agent": agent,
+            "handle": handle,
+            "areas": result["areas"],
+            "conductor_ritual_stage": conductor_ritual["conductor_ritual_stage"],
+        },
     )
 
     return result
@@ -556,6 +601,7 @@ def work_board() -> dict[str, Any]:
         }
         if c.test_obligations:
             entry["test_obligations"] = c.test_obligations
+        entry["conductor_ritual"] = c.ritual_metadata()
         by_agent.setdefault(c.agent, []).append(entry)
         all_test_obligations.extend(c.test_obligations)
 

--- a/src/organvm_engine/coordination/lifecycle.py
+++ b/src/organvm_engine/coordination/lifecycle.py
@@ -55,6 +55,234 @@ def valid_transition(current: AgentPhase, target: AgentPhase) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Conductor lifecycle and Score -> Rehearse -> Perform ritual
+# ---------------------------------------------------------------------------
+
+class ConductorPhase(str, enum.Enum):
+    """Canonical Conductor lifecycle phases owned by ORGAN-IV."""
+
+    FRAME = "FRAME"
+    SHAPE = "SHAPE"
+    BUILD = "BUILD"
+    PROVE = "PROVE"
+    DONE = "DONE"
+
+
+class ConductorRitualStage(str, enum.Enum):
+    """The ritual overlay that gates the Conductor lifecycle."""
+
+    SCORE = "score"
+    REHEARSE = "rehearse"
+    PERFORM = "perform"
+
+
+CONDUCTOR_PHASE_ORDER: list[ConductorPhase] = list(ConductorPhase)
+
+CONDUCTOR_PHASE_TRANSITIONS: dict[ConductorPhase, set[ConductorPhase]] = {
+    ConductorPhase.FRAME: {ConductorPhase.SHAPE},
+    ConductorPhase.SHAPE: {ConductorPhase.BUILD},
+    ConductorPhase.BUILD: {ConductorPhase.PROVE},
+    ConductorPhase.PROVE: {ConductorPhase.DONE},
+    ConductorPhase.DONE: set(),
+}
+
+CONDUCTOR_RITUAL_SEQUENCE: list[ConductorRitualStage] = [
+    ConductorRitualStage.SCORE,
+    ConductorRitualStage.REHEARSE,
+    ConductorRitualStage.PERFORM,
+]
+
+CONDUCTOR_PHASE_RITUAL: dict[ConductorPhase, ConductorRitualStage] = {
+    ConductorPhase.FRAME: ConductorRitualStage.SCORE,
+    ConductorPhase.SHAPE: ConductorRitualStage.SCORE,
+    ConductorPhase.BUILD: ConductorRitualStage.REHEARSE,
+    ConductorPhase.PROVE: ConductorRitualStage.REHEARSE,
+    ConductorPhase.DONE: ConductorRitualStage.PERFORM,
+}
+
+
+@dataclass(frozen=True)
+class ConductorRitualGate:
+    """Metadata required at a lifecycle gate."""
+
+    phase: ConductorPhase
+    stage: ConductorRitualStage
+    required_metadata: tuple[str, ...]
+    prompt: str
+    purpose: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase.value,
+            "ritual_stage": self.stage.value,
+            "required_metadata": list(self.required_metadata),
+            "prompt": self.prompt,
+            "purpose": self.purpose,
+        }
+
+
+CONDUCTOR_RITUAL_GATES: tuple[ConductorRitualGate, ...] = (
+    ConductorRitualGate(
+        phase=ConductorPhase.SHAPE,
+        stage=ConductorRitualStage.SCORE,
+        required_metadata=(
+            "appetite_minutes",
+            "micro_spec.outcome",
+            "micro_spec.non_goals",
+            "micro_spec.acceptance_checks",
+        ),
+        prompt="Score the work before BUILD: appetite, outcome, non-goals, checks.",
+        purpose="Prevents open-ended implementation before the problem is shaped.",
+    ),
+    ConductorRitualGate(
+        phase=ConductorPhase.PROVE,
+        stage=ConductorRitualStage.REHEARSE,
+        required_metadata=(
+            "rehearsal_commands",
+            "test_obligations",
+        ),
+        prompt="Rehearse the change before DONE: enumerate and run verification.",
+        purpose="Turns deferred test obligations into an explicit proof pass.",
+    ),
+    ConductorRitualGate(
+        phase=ConductorPhase.DONE,
+        stage=ConductorRitualStage.PERFORM,
+        required_metadata=(
+            "regression_detected",
+            "postmortem_required",
+            "session_export.conductor_ritual",
+        ),
+        prompt="Perform the close-out: regression result, postmortem if needed, export.",
+        purpose="Makes the final session artifact carry the ritual metadata.",
+    ),
+)
+
+
+def normalise_conductor_phase(phase: ConductorPhase | str) -> ConductorPhase:
+    """Return a canonical Conductor phase or raise for unknown values."""
+    if isinstance(phase, ConductorPhase):
+        return phase
+    try:
+        return ConductorPhase(str(phase).strip().upper())
+    except ValueError as exc:
+        valid = ", ".join(p.value for p in CONDUCTOR_PHASE_ORDER)
+        raise ValueError(f"Unknown Conductor phase {phase!r}; expected one of: {valid}") from exc
+
+
+def valid_conductor_transition(
+    current: ConductorPhase | str,
+    target: ConductorPhase | str,
+) -> bool:
+    """Return True if *target* is a valid successor of *current*."""
+    current_phase = normalise_conductor_phase(current)
+    target_phase = normalise_conductor_phase(target)
+    return target_phase in CONDUCTOR_PHASE_TRANSITIONS.get(current_phase, set())
+
+
+def conductor_ritual_stage(phase: ConductorPhase | str) -> ConductorRitualStage:
+    """Return the Score/Rehearse/Perform stage for a Conductor phase."""
+    return CONDUCTOR_PHASE_RITUAL[normalise_conductor_phase(phase)]
+
+
+def conductor_ritual_contract() -> dict[str, Any]:
+    """Return the engine-side contract the ORGAN-IV Conductor can consume."""
+    return {
+        "schema_version": "conductor-ritual/v1",
+        "source_issue": "a-organvm/organvm-engine#10",
+        "lifecycle": [phase.value for phase in CONDUCTOR_PHASE_ORDER],
+        "transitions": {
+            phase.value: [target.value for target in sorted(targets, key=CONDUCTOR_PHASE_ORDER.index)]
+            for phase, targets in CONDUCTOR_PHASE_TRANSITIONS.items()
+        },
+        "ritual_sequence": [stage.value for stage in CONDUCTOR_RITUAL_SEQUENCE],
+        "phase_to_ritual": {
+            phase.value: stage.value for phase, stage in CONDUCTOR_PHASE_RITUAL.items()
+        },
+        "gates": {gate.phase.value: gate.to_dict() for gate in CONDUCTOR_RITUAL_GATES},
+        "session_export_metadata": [
+            "conductor_lifecycle",
+            "conductor_ritual",
+            "conductor_phase",
+            "conductor_ritual_stage",
+            "appetite_minutes",
+            "micro_spec",
+            "rehearsal_commands",
+            "test_obligations",
+            "regression_detected",
+            "postmortem_required",
+        ],
+    }
+
+
+def _string_list(value: Any) -> list[str]:
+    """Normalize scalar or iterable metadata into a string list."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        return [stripped] if stripped else []
+    try:
+        return [str(item).strip() for item in value if str(item).strip()]
+    except TypeError:
+        text = str(value).strip()
+        return [text] if text else []
+
+
+def build_conductor_ritual_metadata(
+    *,
+    phase: ConductorPhase | str = ConductorPhase.DONE,
+    appetite_minutes: int | None = None,
+    micro_spec: dict[str, Any] | None = None,
+    outcome: str = "",
+    non_goals: list[str] | tuple[str, ...] | str | None = None,
+    acceptance_checks: list[str] | tuple[str, ...] | str | None = None,
+    rehearsal_commands: list[str] | tuple[str, ...] | str | None = None,
+    test_obligations: list[str] | tuple[str, ...] | str | None = None,
+    regression_detected: bool | None = None,
+    postmortem: str = "",
+) -> dict[str, Any]:
+    """Build serializable Score/Rehearse/Perform metadata for a session artifact."""
+    conductor_phase = normalise_conductor_phase(phase)
+    spec = dict(micro_spec or {})
+    if outcome:
+        spec["outcome"] = outcome
+    if non_goals is not None:
+        spec["non_goals"] = _string_list(non_goals)
+    if acceptance_checks is not None:
+        spec["acceptance_checks"] = _string_list(acceptance_checks)
+
+    spec.setdefault("outcome", "")
+    spec.setdefault("non_goals", [])
+    spec.setdefault("acceptance_checks", [])
+
+    return {
+        "schema_version": "conductor-ritual/v1",
+        "source_issue": "a-organvm/organvm-engine#10",
+        "conductor_lifecycle": [phase.value for phase in CONDUCTOR_PHASE_ORDER],
+        "conductor_ritual": [stage.value for stage in CONDUCTOR_RITUAL_SEQUENCE],
+        "conductor_phase": conductor_phase.value,
+        "conductor_ritual_stage": conductor_ritual_stage(conductor_phase).value,
+        "score": {
+            "appetite_minutes": appetite_minutes,
+            "micro_spec": {
+                "outcome": str(spec.get("outcome", "")),
+                "non_goals": _string_list(spec.get("non_goals")),
+                "acceptance_checks": _string_list(spec.get("acceptance_checks")),
+            },
+        },
+        "rehearse": {
+            "rehearsal_commands": _string_list(rehearsal_commands),
+            "test_obligations": _string_list(test_obligations),
+        },
+        "perform": {
+            "regression_detected": regression_detected,
+            "postmortem_required": regression_detected is True,
+            "postmortem": postmortem,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
 # Resource weight vocabulary (shared by claims + tool checkout)
 # ---------------------------------------------------------------------------
 

--- a/src/organvm_engine/git/status.py
+++ b/src/organvm_engine/git/status.py
@@ -194,12 +194,12 @@ def diff_pinned(
 
 def check_uncommitted_files(workspace: Path | str | None = None) -> list[dict]:
     """Check for uncommitted files across all repos in the workspace.
-    
+
     Enforces the 'Nothing Local Only' covenant.
     """
     ws = Path(workspace) if workspace else DEFAULT_WORKSPACE
     uncommitted_reports = []
-    
+
     if not ws.exists():
         return uncommitted_reports
 
@@ -208,28 +208,28 @@ def check_uncommitted_files(workspace: Path | str | None = None) -> list[dict]:
         organ_path = ws / organ_dir
         if not (organ_path / ".git").exists():
             continue
-            
+
         result = _run_git(["submodule", "status"], organ_path)
         if result.returncode != 0:
             continue
-            
+
         for line in result.stdout.rstrip("\n").split("\n"):
             if not line.strip():
                 continue
             parts = line[1:].strip().split()
             if len(parts) < 2:
                 continue
-                
+
             repo_name = parts[1]
             repo_path = organ_path / repo_name
-            
+
             if not (repo_path / ".git").exists():
                 continue
-                
+
             status_result = _run_git(["status", "--porcelain"], repo_path)
             if status_result.returncode != 0:
                 continue
-                
+
             files = [line for line in status_result.stdout.strip().split("\n") if line.strip()]
             if files:
                 uncommitted_reports.append(
@@ -237,8 +237,8 @@ def check_uncommitted_files(workspace: Path | str | None = None) -> list[dict]:
                         "organ": organ_dir,
                         "repo": repo_name,
                         "uncommitted_count": len(files),
-                        "files": files[:5] + (["..."] if len(files) > 5 else [])
-                    }
+                        "files": files[:5] + (["..."] if len(files) > 5 else []),
+                    },
                 )
-                
+
     return uncommitted_reports

--- a/src/organvm_engine/governance/feedback_loops.py
+++ b/src/organvm_engine/governance/feedback_loops.py
@@ -171,10 +171,14 @@ def _canonical_negative_loops() -> list[FeedbackLoop]:
             stratum=LoopStratum.TOOLING,
             description=(
                 "FRAME→SHAPE→BUILD→PROVE→DONE lifecycle prevents premature "
-                "implementation. Hard gates enforce sequential progression."
+                "implementation. Score→Rehearse→Perform metadata gates appetite, "
+                "micro-spec, verification, regression/postmortem, and export."
             ),
             nodes=["conductor", "session"],
-            governing_mechanism="conductor session lifecycle (ORGAN-IV)",
+            governing_mechanism=(
+                "coordination/lifecycle.py conductor_ritual_contract() + "
+                "conductor session lifecycle (ORGAN-IV)"
+            ),
         ),
         FeedbackLoop(
             name="registry-boundary",

--- a/src/organvm_engine/session/debrief.py
+++ b/src/organvm_engine/session/debrief.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from organvm_engine.coordination.lifecycle import build_conductor_ritual_metadata
+
 
 @dataclass
 class FileTouch:
@@ -54,6 +56,21 @@ class SessionDebrief:
     medium_todos: list[str] = field(default_factory=list)
     small_todos: list[str] = field(default_factory=list)
 
+    def conductor_ritual_metadata(self) -> dict[str, Any]:
+        """Return Score/Rehearse/Perform metadata for debrief export."""
+        test_commands = [cmd for cmd in self.bash_commands if _is_test_command(cmd)]
+        return build_conductor_ritual_metadata(
+            phase="DONE",
+            appetite_minutes=self.duration_minutes,
+            micro_spec={
+                "outcome": self.human_prompts[0] if self.human_prompts else "",
+                "acceptance_checks": test_commands,
+            },
+            rehearsal_commands=test_commands,
+            test_obligations=test_commands,
+            regression_detected=None,
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "session_id": self.session_id,
@@ -72,6 +89,7 @@ class SessionDebrief:
             "big_todos": self.big_todos,
             "medium_todos": self.medium_todos,
             "small_todos": self.small_todos,
+            "conductor_ritual": self.conductor_ritual_metadata(),
         }
 
 
@@ -367,6 +385,33 @@ def render_debrief(debrief: SessionDebrief) -> str:
         for f in debrief.files_edited:
             lines.append(f"- `{_short_path(f)}`")
         lines.append("")
+
+    ritual = debrief.conductor_ritual_metadata()
+    lifecycle = " -> ".join(ritual["conductor_lifecycle"])
+    ritual_sequence = " -> ".join(stage.title() for stage in ritual["conductor_ritual"])
+    appetite = ritual["score"]["appetite_minutes"]
+    appetite_value = f"{appetite} min" if appetite is not None else "unknown"
+    rehearsal_commands = ritual["rehearse"]["rehearsal_commands"]
+
+    lines.append("## Conductor Ritual")
+    lines.append("")
+    lines.append(f"**Lifecycle:** `{lifecycle}`")
+    lines.append(f"**Ritual:** `{ritual_sequence}`")
+    lines.append(f"**Phase:** `{ritual['conductor_phase']}`")
+    lines.append(f"**Stage:** `{ritual['conductor_ritual_stage']}`")
+    lines.append("")
+    lines.append(f"- **Score:** appetite `{appetite_value}`; micro-spec outcome captured.")
+    if rehearsal_commands:
+        lines.append(
+            f"- **Rehearse:** {len(rehearsal_commands)} verification command(s) recorded.",
+        )
+    else:
+        lines.append("- **Rehearse:** no verification commands recorded.")
+    lines.append(
+        "- **Perform:** regression status `not-recorded`; "
+        f"postmortem_required `{ritual['perform']['postmortem_required']}`.",
+    )
+    lines.append("")
 
     # Tiered to-dos
     lines.append("## To-Dos")

--- a/src/organvm_engine/session/parser.py
+++ b/src/organvm_engine/session/parser.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from organvm_engine.coordination.lifecycle import build_conductor_ritual_metadata
+
 CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 
 
@@ -233,6 +235,16 @@ class SessionExport:
         if len(first_msg) > 200:
             first_msg = first_msg[:200] + "..."
 
+        ritual = build_conductor_ritual_metadata(
+            phase="DONE",
+            appetite_minutes=self.meta.duration_minutes,
+            micro_spec={"outcome": first_msg},
+        )
+        lifecycle = " -> ".join(ritual["conductor_lifecycle"])
+        ritual_sequence = " -> ".join(stage.title() for stage in ritual["conductor_ritual"])
+        appetite = ritual["score"]["appetite_minutes"]
+        appetite_value = str(appetite) if appetite is not None else "unknown"
+
         return f"""# Session Review: {date} -- {self.slug}
 
 **Date:** {date}
@@ -258,6 +270,22 @@ organvm session prompts {short_id}
 ```
 
 **Source JSONL:** `{self.meta.file_path}`
+
+---
+
+## Conductor Ritual Metadata
+
+| Field | Value |
+|-------|-------|
+| schema_version | `{ritual["schema_version"]}` |
+| conductor_lifecycle | `{lifecycle}` |
+| conductor_ritual | `{ritual_sequence}` |
+| conductor_phase | `{ritual["conductor_phase"]}` |
+| conductor_ritual_stage | `{ritual["conductor_ritual_stage"]}` |
+| appetite_minutes | `{appetite_value}` |
+| micro_spec.outcome | {first_msg or "[TODO]"} |
+| regression_detected | `not-recorded` |
+| postmortem_required | `{ritual["perform"]["postmortem_required"]}` |
 
 ---
 

--- a/tests/test_conductor_lifecycle.py
+++ b/tests/test_conductor_lifecycle.py
@@ -1,0 +1,96 @@
+"""Tests for Conductor lifecycle ritual contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from organvm_engine.coordination.lifecycle import (
+    CONDUCTOR_PHASE_ORDER,
+    ConductorPhase,
+    ConductorRitualStage,
+    build_conductor_ritual_metadata,
+    conductor_ritual_contract,
+    conductor_ritual_stage,
+    normalise_conductor_phase,
+    valid_conductor_transition,
+)
+
+
+class TestConductorLifecycle:
+    def test_phase_order(self):
+        assert [phase.value for phase in CONDUCTOR_PHASE_ORDER] == [
+            "FRAME",
+            "SHAPE",
+            "BUILD",
+            "PROVE",
+            "DONE",
+        ]
+
+    def test_valid_transitions_are_sequential(self):
+        assert valid_conductor_transition("FRAME", "SHAPE")
+        assert valid_conductor_transition(ConductorPhase.BUILD, ConductorPhase.PROVE)
+        assert not valid_conductor_transition("FRAME", "BUILD")
+        assert not valid_conductor_transition("DONE", "PROVE")
+
+    def test_phase_normalization(self):
+        assert normalise_conductor_phase("shape") == ConductorPhase.SHAPE
+        with pytest.raises(ValueError, match="Unknown Conductor phase"):
+            normalise_conductor_phase("PLAN")
+
+    def test_ritual_stage_mapping(self):
+        assert conductor_ritual_stage("FRAME") == ConductorRitualStage.SCORE
+        assert conductor_ritual_stage("SHAPE") == ConductorRitualStage.SCORE
+        assert conductor_ritual_stage("BUILD") == ConductorRitualStage.REHEARSE
+        assert conductor_ritual_stage("PROVE") == ConductorRitualStage.REHEARSE
+        assert conductor_ritual_stage("DONE") == ConductorRitualStage.PERFORM
+
+    def test_contract_names_gates(self):
+        contract = conductor_ritual_contract()
+
+        assert contract["schema_version"] == "conductor-ritual/v1"
+        assert contract["ritual_sequence"] == ["score", "rehearse", "perform"]
+        assert contract["phase_to_ritual"]["SHAPE"] == "score"
+        assert contract["phase_to_ritual"]["PROVE"] == "rehearse"
+        assert contract["phase_to_ritual"]["DONE"] == "perform"
+        assert "appetite_minutes" in contract["gates"]["SHAPE"]["required_metadata"]
+        assert "test_obligations" in contract["gates"]["PROVE"]["required_metadata"]
+        assert (
+            "session_export.conductor_ritual"
+            in contract["gates"]["DONE"]["required_metadata"]
+        )
+
+
+class TestConductorRitualMetadata:
+    def test_builds_score_rehearse_perform_payload(self):
+        metadata = build_conductor_ritual_metadata(
+            phase="SHAPE",
+            appetite_minutes=45,
+            micro_spec={
+                "outcome": "formalize ritual",
+                "non_goals": ["implement ORGAN-IV server"],
+                "acceptance_checks": ["pytest tests/test_conductor_lifecycle.py"],
+            },
+            test_obligations=["pytest tests/test_conductor_lifecycle.py"],
+            regression_detected=False,
+        )
+
+        assert metadata["conductor_phase"] == "SHAPE"
+        assert metadata["conductor_ritual_stage"] == "score"
+        assert metadata["score"]["appetite_minutes"] == 45
+        assert metadata["score"]["micro_spec"]["outcome"] == "formalize ritual"
+        assert metadata["rehearse"]["test_obligations"] == [
+            "pytest tests/test_conductor_lifecycle.py",
+        ]
+        assert metadata["perform"]["regression_detected"] is False
+        assert metadata["perform"]["postmortem_required"] is False
+
+    def test_regression_requires_postmortem(self):
+        metadata = build_conductor_ritual_metadata(
+            phase="DONE",
+            regression_detected=True,
+            postmortem="pytest regression in prove gate",
+        )
+
+        assert metadata["conductor_ritual_stage"] == "perform"
+        assert metadata["perform"]["postmortem_required"] is True
+        assert metadata["perform"]["postmortem"] == "pytest regression in prove gate"

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -78,6 +78,31 @@ class TestWorkClaim:
         assert restored.agent == "gemini"
         assert restored.organs == ["META"]
 
+    def test_ritual_metadata_roundtrip(self):
+        claim = WorkClaim(
+            claim_id="abc",
+            agent="codex",
+            session_id="s3",
+            timestamp=12345.0,
+            conductor_phase="SHAPE",
+            appetite_minutes=30,
+            micro_spec={
+                "outcome": "formalize lifecycle",
+                "non_goals": ["own ORGAN-IV implementation"],
+                "acceptance_checks": ["pytest tests/test_conductor_lifecycle.py"],
+            },
+            test_obligations=["pytest tests/test_conductor_lifecycle.py"],
+        )
+
+        d = claim.to_dict()
+        restored = WorkClaim.from_dict(d)
+
+        assert restored.conductor_phase == "SHAPE"
+        assert restored.appetite_minutes == 30
+        assert restored.micro_spec["outcome"] == "formalize lifecycle"
+        assert restored.ritual_metadata()["conductor_ritual_stage"] == "score"
+        assert restored.ritual_metadata()["score"]["appetite_minutes"] == 30
+
 
 class TestBuildActiveClaims:
     def test_empty(self):
@@ -165,6 +190,31 @@ class TestPunchIn:
         )
         assert result["conflict_count"] == 0
 
+    def test_punch_in_accepts_conductor_ritual_metadata(self):
+        result = punch_in(
+            agent="codex",
+            session_id="s1",
+            repos=["organvm-engine"],
+            scope="formalize Score Rehearse Perform lifecycle",
+            conductor_phase="SHAPE",
+            appetite_minutes=45,
+            micro_spec={
+                "outcome": "engine-side ritual contract",
+                "non_goals": ["implement Conductor MCP server"],
+                "acceptance_checks": ["pytest tests/test_conductor_lifecycle.py"],
+            },
+            test_obligations=["pytest tests/test_conductor_lifecycle.py"],
+        )
+
+        ritual = result["conductor_ritual"]
+        assert ritual["conductor_phase"] == "SHAPE"
+        assert ritual["conductor_ritual_stage"] == "score"
+        assert ritual["score"]["appetite_minutes"] == 45
+        assert ritual["score"]["micro_spec"]["outcome"] == "engine-side ritual contract"
+        assert ritual["rehearse"]["test_obligations"] == [
+            "pytest tests/test_conductor_lifecycle.py",
+        ]
+
 
 class TestPunchOut:
     def test_basic_punch_out(self):
@@ -229,6 +279,23 @@ class TestWorkBoard:
         assert board["agents_working"] == 2
         assert "claude" in board["by_agent"]
         assert "gemini" in board["by_agent"]
+
+    def test_board_includes_conductor_ritual(self):
+        punch_in(
+            agent="codex",
+            session_id="s1",
+            repos=["organvm-engine"],
+            conductor_phase="PROVE",
+            test_obligations=["pytest tests/test_coordination.py"],
+        )
+
+        board = work_board()
+        entry = board["by_agent"]["codex"][0]
+        assert entry["conductor_ritual"]["conductor_phase"] == "PROVE"
+        assert entry["conductor_ritual"]["conductor_ritual_stage"] == "rehearse"
+        assert entry["conductor_ritual"]["rehearse"]["test_obligations"] == [
+            "pytest tests/test_coordination.py",
+        ]
 
     def test_board_excludes_released(self):
         r = punch_in(agent="claude", session_id="s1", organs=["ORGAN-I"])

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -283,6 +283,11 @@ class TestSessionExport:
         assert "--unabridged" in content
         assert "organvm session prompts test-123" in content
         assert "Source JSONL" in content
+        assert "## Conductor Ritual Metadata" in content
+        assert "conductor_lifecycle" in content
+        assert "`FRAME -> SHAPE -> BUILD -> PROVE -> DONE`" in content
+        assert "conductor_ritual_stage" in content
+        assert "`perform`" in content
 
     def test_export_write(self, tmp_path):
         meta = SessionMeta(

--- a/tests/test_session_debrief.py
+++ b/tests/test_session_debrief.py
@@ -246,6 +246,8 @@ class TestRenderDebrief:
         md = render_debrief(debrief)
         assert "# Session Debrief" in md
         assert "## Analysis" in md
+        assert "## Conductor Ritual" in md
+        assert "Score -> Rehearse -> Perform" in md
         assert "## To-Dos" in md
 
     def test_renders_file_lists(self, sample_session: Path):
@@ -277,6 +279,11 @@ class TestToDict:
         assert isinstance(d["small_todos"], list)
         assert d["test_runs"] == 1
         assert d["commits_made"] == 1
+        assert d["conductor_ritual"]["conductor_phase"] == "DONE"
+        assert d["conductor_ritual"]["conductor_ritual_stage"] == "perform"
+        assert d["conductor_ritual"]["rehearse"]["rehearsal_commands"] == [
+            "pytest organvm-engine/tests/ -v",
+        ]
 
 
 class TestHelpers:


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-078`.

Audited 2026-06-01 from Jules-ready batch. feat: formalize Score→Rehearse→Perform ritual in Conductor lifecycle

Refs: https://github.com/a-organvm/organvm-engine/issues/10

_Produced in an isolated worktree off origin — review before merge._