### PR TITLE
[limen LIMEN-073] descent: add type-checking to 6 remaining repos

### DIFF
--- a/src/organvm_engine/ci/audit.py
+++ b/src/organvm_engine/ci/audit.py
@@ -21,7 +21,11 @@ from enum import Enum
 from pathlib import Path
 
 from organvm_engine.ci.mandate import _check_ci_workflows, _resolve_repo_path
-from organvm_engine.organ_config import registry_key_to_dir
+from organvm_engine.organ_config import (
+    get_topology_source,
+    load_organ_topology,
+    registry_key_to_dir,
+)
 from organvm_engine.paths import workspace_root
 
 
@@ -668,6 +672,8 @@ def run_infra_audit(
         InfraAuditReport with per-repo compliance results.
     """
     ws = workspace or workspace_root()
+    if get_topology_source() == "fallback":
+        load_organ_topology()
     key_to_dir = registry_key_to_dir()
     report = InfraAuditReport()
 

--- a/src/organvm_engine/ci/mandate.py
+++ b/src/organvm_engine/ci/mandate.py
@@ -10,11 +10,17 @@ so it can be consumed by governance audit, MCP server, and CLI.
 
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from organvm_engine.organ_config import registry_key_to_dir
-from organvm_engine.paths import workspace_root
+from organvm_engine.organ_config import (
+    get_organ_map,
+    get_topology_source,
+    load_organ_topology,
+    registry_key_to_dir,
+)
+from organvm_engine.paths import additional_workspace_roots, corpus_dir, workspace_root
 
 
 @dataclass
@@ -99,19 +105,42 @@ def _resolve_repo_path(
 
     Strategy:
     1. Use organ directory mapping from organ_config
-    2. Fall back to org name as directory
+    2. Use the loaded topology's GitHub org directory, if present
+    3. Fall back to registry org name as directory
+    4. Fall back to the corpus parent and any configured flat workspace roots
     """
-    # Map registry key to workspace directory
+    candidates: list[Path] = []
+
+    def add(candidate: Path) -> None:
+        if candidate not in candidates:
+            candidates.append(candidate)
+
     organ_dir = key_to_dir.get(organ_key)
     if organ_dir:
-        candidate = ws / organ_dir / repo_name
+        add(ws / organ_dir / repo_name)
+
+    for entry in get_organ_map().values():
+        if entry.get("registry_key") != organ_key:
+            continue
+        topo_dir = entry.get("dir")
+        topo_org = entry.get("org")
+        if topo_dir:
+            add(ws / topo_dir / repo_name)
+        if topo_org:
+            add(ws / topo_org / repo_name)
+
+    if org:
+        add(ws / org / repo_name)
+
+    with suppress(OSError):
+        add(corpus_dir().parent / repo_name)
+
+    for root in additional_workspace_roots(workspace=ws):
+        add(root / repo_name)
+
+    for candidate in candidates:
         if candidate.is_dir():
             return candidate
-
-    # Fall back to org-name directory
-    candidate = ws / org / repo_name
-    if candidate.is_dir():
-        return candidate
 
     # Special case: .github repos may be at org level
     if repo_name == ".github" and organ_dir:
@@ -150,6 +179,8 @@ def verify_ci_mandate(
         CIMandateReport with per-repo verification results.
     """
     ws = workspace or workspace_root()
+    if get_topology_source() == "fallback":
+        load_organ_topology()
     key_to_dir = registry_key_to_dir()
     report = CIMandateReport()
 

--- a/src/organvm_engine/ci/scaffold.py
+++ b/src/organvm_engine/ci/scaffold.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from textwrap import dedent
+from textwrap import dedent, indent
 
 
 class Stack(str, Enum):
@@ -182,7 +182,9 @@ def _wrap_workflow(repo_name: str, stack: Stack, steps_block: str) -> str:
       - name: Install Node dependencies
         run: npm ci"""))
 
-    setup_block = "\n".join(setup_lines)
+    setup_block = "\n".join(setup_lines).strip()
+    setup_block = indent(setup_block, "      ") if setup_block else ""
+    steps_block = indent(steps_block.strip(), "      ")
 
     return dedent(f"""\
 # CI workflow for {repo_name}

--- a/src/organvm_engine/cli/__init__.py
+++ b/src/organvm_engine/cli/__init__.py
@@ -999,8 +999,7 @@ def build_parser() -> argparse.ArgumentParser:
     ci_scaffold.add_argument(
         "--all",
         action="store_true",
-        default=True,
-        help="Include all steps (default)",
+        help="Include all steps (default when no step flags are selected)",
     )
     ci_scaffold.add_argument(
         "--dry-run",

--- a/src/organvm_engine/cli/ci.py
+++ b/src/organvm_engine/cli/ci.py
@@ -17,13 +17,15 @@ def cmd_ci_scaffold(args: argparse.Namespace) -> int:
 
     repo_name = getattr(args, "name", None) or repo_path.name
     dry_run = not getattr(args, "write", False)
+    explicit_steps = bool(args.lint or args.test or args.typecheck)
+    include_all = bool(args.all or not explicit_steps)
 
     result = scaffold_repo(
         repo_path=repo_path,
         repo_name=repo_name,
-        lint=args.lint or args.all,
-        test=args.test or args.all,
-        typecheck=args.typecheck or args.all,
+        lint=args.lint or include_all,
+        test=args.test or include_all,
+        typecheck=args.typecheck or include_all,
     )
 
     if args.json:

--- a/src/organvm_engine/organ_config.py
+++ b/src/organvm_engine/organ_config.py
@@ -203,6 +203,8 @@ def _parse_topology_dict(data: Any) -> dict[str, dict[str, str]] | None:
     result: dict[str, dict[str, str]] = {}
     all_errors: list[str] = []
     for key, entry in organs_data.items():
+        if isinstance(key, str) and key.startswith("_"):
+            continue
         if not isinstance(entry, dict):
             all_errors.append(f"Organ '{key}' must be a dict")
             continue

--- a/src/organvm_engine/paths.py
+++ b/src/organvm_engine/paths.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 _DEFAULT_WORKSPACE = Path.home() / "Workspace"
 _DEFAULT_CORPUS_SUBPATH = "meta-organvm/organvm-corpvs-testamentvm"
+_DEFAULT_A_ORGANVM_SUBPATH = "a-organvm/organvm-corpvs-testamentvm"
 # Corpus relocated to the Code root (2026-06 consolidation). Bare launchd
 # daemons do not inherit shell-profile env vars, so corpus_dir() must be able
 # to find the real corpus without ORGANVM_CORPUS_DIR. A directory only counts
@@ -56,8 +57,10 @@ class PathConfig:
         env = os.environ.get("ORGANVM_CORPUS_DIR")
         if env:
             return _coerce_path(env)
-        legacy = self.workspace_root() / _DEFAULT_CORPUS_SUBPATH
-        for candidate in (legacy, _DEFAULT_CODE_ROOT / _CORPUS_REPO_NAME):
+        workspace = self.workspace_root()
+        legacy = workspace / _DEFAULT_CORPUS_SUBPATH
+        consolidated = workspace / _DEFAULT_A_ORGANVM_SUBPATH
+        for candidate in (legacy, consolidated, _DEFAULT_CODE_ROOT / _CORPUS_REPO_NAME):
             if _holds_registry(candidate):
                 return candidate
         return legacy

--- a/tests/test_ci_audit.py
+++ b/tests/test_ci_audit.py
@@ -331,6 +331,57 @@ class TestRunInfraAudit:
         assert report.total_repos == 1
         assert len(report.repos) == 1
 
+    def test_audit_resolves_consolidated_a_organvm_layout(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Audit uses loaded topology orgs for post-consolidation flat checkouts."""
+        from organvm_engine.organ_config import reset_topology
+
+        corpus = tmp_path / "a-organvm" / "organvm-corpvs-testamentvm"
+        corpus.mkdir(parents=True)
+        (corpus / "repo-registry.json").write_text("{}")
+        (corpus / "organ-topology.json").write_text(json.dumps({
+            "I": {"dir": "organvm", "registry_key": "ORGAN-I", "org": "a-organvm"},
+        }))
+        monkeypatch.setenv("ORGANVM_CORPUS_DIR", str(corpus))
+
+        repo = tmp_path / "a-organvm" / "repo-a"
+        repo.mkdir(parents=True)
+        (repo / "pyproject.toml").write_text("[project]\nname = 'repo-a'")
+        workflows = repo / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text(
+            "name: CI\njobs:\n  test:\n    steps:\n      - run: pyright src/\n",
+        )
+        (repo / ".github" / "dependabot.yml").write_text("version: 2\n")
+
+        registry = {
+            "organs": {
+                "ORGAN-I": {
+                    "repositories": [
+                        {
+                            "name": "repo-a",
+                            "org": "organvm-i-theoria",
+                            "promotion_status": "LOCAL",
+                            "tier": "standard",
+                        },
+                    ],
+                },
+            },
+        }
+
+        try:
+            report = run_infra_audit(registry, workspace=tmp_path, repo_filter="repo-a")
+            assert report.total_repos == 1
+            result = report.repos[0]
+            assert result.repo_path == repo
+            typecheck = next(c for c in result.checks if c.mechanism == "type_checking")
+            assert typecheck.status == CheckStatus.PASS
+        finally:
+            reset_topology()
+
     def test_organ_filter(self, tmp_path: Path):
         registry = {
             "organs": {

--- a/tests/test_ci_scaffold.py
+++ b/tests/test_ci_scaffold.py
@@ -1,5 +1,7 @@
 """Tests for ci/scaffold.py — CI workflow YAML generation."""
 
+import argparse
+import json
 from pathlib import Path
 
 import pytest
@@ -9,6 +11,7 @@ from organvm_engine.ci.scaffold import (
     detect_stack,
     scaffold_repo,
 )
+from organvm_engine.cli.ci import cmd_ci_scaffold
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -203,3 +206,62 @@ class TestCombinedYaml:
         assert "push:" in combined
         assert "pull_request:" in combined
         assert "branches: [main]" in combined
+
+    def test_combined_yaml_parses(self, python_repo: Path):
+        yaml = pytest.importorskip("yaml")
+        result = scaffold_repo(
+            python_repo,
+            "test-repo",
+            lint=False,
+            test=False,
+            typecheck=True,
+        )
+        parsed = yaml.safe_load(result.combined_yaml())
+        assert parsed["jobs"]["ci"]["steps"][1]["name"] == "Set up Python"
+        assert parsed["jobs"]["ci"]["steps"][3]["name"] == "Type check (pyright)"
+
+
+# ---------------------------------------------------------------------------
+# CLI flag behavior
+# ---------------------------------------------------------------------------
+
+class TestScaffoldCli:
+    def test_typecheck_flag_generates_typecheck_only(self, python_repo: Path, capsys):
+        args = argparse.Namespace(
+            path=str(python_repo),
+            name=None,
+            lint=False,
+            test=False,
+            typecheck=True,
+            all=False,
+            write=False,
+            json=True,
+        )
+
+        rc = cmd_ci_scaffold(args)
+        out = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert "typecheck_step" in out
+        assert "lint_step" not in out
+        assert "test_step" not in out
+
+    def test_no_step_flags_defaults_to_all(self, python_repo: Path, capsys):
+        args = argparse.Namespace(
+            path=str(python_repo),
+            name=None,
+            lint=False,
+            test=False,
+            typecheck=False,
+            all=False,
+            write=False,
+            json=True,
+        )
+
+        rc = cmd_ci_scaffold(args)
+        out = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert "lint_step" in out
+        assert "test_step" in out
+        assert "typecheck_step" in out

--- a/tests/test_organ_config_topology.py
+++ b/tests/test_organ_config_topology.py
@@ -196,6 +196,18 @@ class TestValidation:
         assert "I" in result
         assert "BAD" not in result
 
+    def test_underscore_metadata_keys_are_ignored(self, tmp_path):
+        topology = {
+            "_comment": "metadata, not an organ",
+            "I": {"dir": "good", "registry_key": "ORGAN-I", "org": "good-org"},
+        }
+        path = tmp_path / "topology.json"
+        path.write_text(json.dumps(topology))
+        result = load_organ_topology(path)
+        assert result == {
+            "I": {"dir": "good", "registry_key": "ORGAN-I", "org": "good-org"},
+        }
+
     def test_non_dict_entry_rejected(self, tmp_path):
         bad = {"I": "not-a-dict"}
         path = tmp_path / "bad.json"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -63,6 +63,20 @@ class TestPaths:
         monkeypatch.setattr(paths, "_DEFAULT_CODE_ROOT", code_root)
         assert paths.corpus_dir() == corpus
 
+    def test_corpus_dir_uses_consolidated_a_organvm_corpus(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ORGANVM_WORKSPACE_DIR", raising=False)
+        husk = tmp_path / "ws" / "meta-organvm" / "organvm-corpvs-testamentvm"
+        husk.mkdir(parents=True)
+        (husk / "CLAUDE.md").write_text("husk")
+        corpus = tmp_path / "ws" / "a-organvm" / "organvm-corpvs-testamentvm"
+        corpus.mkdir(parents=True)
+        (corpus / "repo-registry.json").write_text("{}")
+        code_root = tmp_path / "code-organvm"
+        code_root.mkdir()
+        monkeypatch.setattr(paths, "_DEFAULT_WORKSPACE", tmp_path / "ws")
+        monkeypatch.setattr(paths, "_DEFAULT_CODE_ROOT", code_root)
+        assert paths.corpus_dir() == corpus
+
     def test_corpus_dir_prefers_legacy_when_it_holds_registry(self, tmp_path, monkeypatch):
         monkeypatch.delenv("ORGANVM_WORKSPACE_DIR", raising=False)
         legacy = tmp_path / "ws" / "meta-organvm" / "organvm-corpvs-testamentvm"


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-073`.

Audited 2026-06-01 from Jules-ready batch. descent: add type-checking to 6 remaining repos

Refs: https://github.com/a-organvm/organvm-engine/issues/60

_Produced in an isolated worktree off origin — review before merge._