### PR TITLE
[limen LIMEN-060] feat: implement MCP tool wrappers for all 5 organvm CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- MCP tool layer (`organvm_engine.mcp`): pure, JSON-serializable wrappers
+  exposing the five core CLIs (registry, governance, seed, metrics, dispatch)
+  to the `organvm-mcp-server` without an MCP-SDK dependency. Includes a
+  `MCP_TOOLS` manifest plus `list_tools()` / `call_tool()` for generic
+  registration and dispatch.
+
 ## 0.1.0 (2026-02-17)
 
 - Initial release: 5 modules (registry, governance, seed, metrics, dispatch)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ print(result.summary())
 | `metrics` | Compute and propagate system-wide metrics |
 | `dispatch` | Cross-organ event routing and cascade planning |
 | `contextmd` | Sync AI context files and discover exported conversation-corpus surfaces |
+| `mcp` | JSON-serializable tool wrappers exposing the 5 core CLIs to `organvm-mcp-server` |
 
 ## Part of the Eight-Organ System
 

--- a/src/organvm_engine/mcp/__init__.py
+++ b/src/organvm_engine/mcp/__init__.py
@@ -1,0 +1,170 @@
+"""MCP tool layer for organvm-engine (LIMEN-060).
+
+A single discovery point that the MCP server in ``organvm-mcp-server``
+imports to expose the five core organvm CLIs (registry, governance,
+seed, metrics, dispatch) as MCP tools — without this package depending
+on the MCP SDK.
+
+Each tool is a pure function returning a JSON-serializable dict (see
+``organvm_engine.mcp.tools``). ``MCP_TOOLS`` describes them as
+``ToolSpec`` records so a server can register them generically:
+
+    from organvm_engine.mcp import MCP_TOOLS, call_tool, list_tools
+
+    for spec in MCP_TOOLS:
+        server.register(spec.name, spec.handler, spec.description)
+
+    # or dispatch by name:
+    result = call_tool("registry_stats")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from organvm_engine.mcp import tools
+
+__all__ = [
+    "ToolSpec",
+    "MCP_TOOLS",
+    "TOOLS_BY_NAME",
+    "list_tools",
+    "call_tool",
+]
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Description of a single MCP tool.
+
+    Attributes
+    ----------
+    name:
+        Stable tool name (``<cli>_<verb>``) used for registration/dispatch.
+    cli:
+        The organvm CLI group this tool wraps.
+    description:
+        One-line summary, suitable for an MCP tool manifest.
+    handler:
+        The pure callable returning a JSON-serializable dict.
+    """
+
+    name: str
+    cli: str
+    description: str
+    handler: Callable[..., dict[str, Any]]
+
+
+MCP_TOOLS: list[ToolSpec] = [
+    # registry
+    ToolSpec(
+        "registry_show", "registry",
+        "Return the full registry record for a single repo.",
+        tools.registry_show,
+    ),
+    ToolSpec(
+        "registry_list", "registry",
+        "List repos with optional organ/status/tier/promotion filters.",
+        tools.registry_list,
+    ),
+    ToolSpec(
+        "registry_search", "registry",
+        "Search repositories by text query across selected fields.",
+        tools.registry_search,
+    ),
+    ToolSpec(
+        "registry_stats", "registry",
+        "Return registry-wide statistics (counts by organ/status/tier).",
+        tools.registry_stats,
+    ),
+    ToolSpec(
+        "registry_deps", "registry",
+        "Return dependency and/or dependent edges for a repo.",
+        tools.registry_deps,
+    ),
+    ToolSpec(
+        "registry_validate", "registry",
+        "Validate registry schema/integrity; return errors and warnings.",
+        tools.registry_validate,
+    ),
+    # governance
+    ToolSpec(
+        "governance_audit", "governance",
+        "Run the full governance audit (critical/warnings/info).",
+        tools.governance_audit,
+    ),
+    ToolSpec(
+        "governance_check_deps", "governance",
+        "Validate the dependency graph (missing targets, cycles, back-edges).",
+        tools.governance_check_deps,
+    ),
+    ToolSpec(
+        "governance_impact", "governance",
+        "Return the downstream blast radius for a change to a repo.",
+        tools.governance_impact,
+    ),
+    # seed
+    ToolSpec(
+        "seed_discover", "seed",
+        "List discovered seed.yaml files as org/repo identities.",
+        tools.seed_discover,
+    ),
+    ToolSpec(
+        "seed_validate", "seed",
+        "Validate that every seed.yaml has the required top-level fields.",
+        tools.seed_validate,
+    ),
+    ToolSpec(
+        "seed_graph", "seed",
+        "Build the produces/consumes graph across all seeds.",
+        tools.seed_graph,
+    ),
+    # metrics
+    ToolSpec(
+        "metrics_calculate", "metrics",
+        "Compute system-wide metrics from the registry (no write).",
+        tools.metrics_calculate,
+    ),
+    # dispatch
+    ToolSpec(
+        "dispatch_validate", "dispatch",
+        "Validate a dispatch event payload against the schema.",
+        tools.dispatch_validate,
+    ),
+]
+
+TOOLS_BY_NAME: dict[str, ToolSpec] = {spec.name: spec for spec in MCP_TOOLS}
+
+
+def list_tools() -> list[dict[str, str]]:
+    """Return a serializable manifest of all tools (name, cli, description)."""
+    return [
+        {"name": spec.name, "cli": spec.cli, "description": spec.description}
+        for spec in MCP_TOOLS
+    ]
+
+
+def call_tool(name: str, **kwargs: Any) -> dict[str, Any]:
+    """Dispatch a tool call by name.
+
+    Parameters
+    ----------
+    name:
+        One of the registered tool names (see ``TOOLS_BY_NAME``).
+    **kwargs:
+        Keyword arguments forwarded to the tool handler.
+
+    Returns
+    -------
+    dict
+        The handler's JSON-serializable result, or ``{"error": ...}`` if
+        the tool name is unknown.
+    """
+    spec = TOOLS_BY_NAME.get(name)
+    if spec is None:
+        return {
+            "error": f"Unknown tool {name!r}. "
+            f"Valid: {', '.join(sorted(TOOLS_BY_NAME))}",
+        }
+    return spec.handler(**kwargs)

--- a/src/organvm_engine/mcp/tools.py
+++ b/src/organvm_engine/mcp/tools.py
@@ -1,0 +1,412 @@
+"""MCP tool functions for the five core organvm CLIs (LIMEN-060).
+
+Exposes the ``registry``, ``governance``, ``seed``, ``metrics``, and
+``dispatch`` command groups as pure functions returning JSON-serializable
+dicts. These functions are consumed by the MCP server in
+organvm-mcp-server — they do NOT depend on the MCP SDK and they never
+print to stdout (CLI handlers do that; these return structured data).
+
+Read-only by default: none of these tools mutate the registry or write
+files. They mirror the ``--json`` projections the CLI already offers and,
+where the CLI only renders text, build an equivalent structured payload.
+
+Tools
+-----
+registry_show       — full record for a single repo
+registry_list       — filtered repo list
+registry_search     — text search across repos
+registry_stats      — registry-wide statistics
+registry_deps       — dependency / dependent edges for a repo
+registry_validate   — schema / integrity validation report
+governance_audit    — full governance audit (critical/warnings/info)
+governance_check_deps — dependency-graph validation report
+governance_impact   — blast-radius / downstream impact for a repo
+seed_discover       — list discovered seed.yaml files
+seed_validate       — validate required fields across seeds
+seed_graph          — produces/consumes graph summary
+metrics_calculate   — compute system metrics (no write side effects)
+dispatch_validate   — validate a dispatch event payload
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# registry
+# ---------------------------------------------------------------------------
+
+
+def registry_show(repo: str, registry_path: str | None = None) -> dict[str, Any]:
+    """Return the full registry record for a single repo.
+
+    Parameters
+    ----------
+    repo:
+        Repository name or resolvable entity alias.
+    registry_path:
+        Optional path to a registry-v2.json file. Defaults to the
+        canonical production registry.
+    """
+    from organvm_engine.registry.loader import load_registry
+    from organvm_engine.registry.query import find_repo, resolve_entity
+
+    registry = load_registry(registry_path)
+    resolved = resolve_entity(repo, registry=registry)
+    if resolved and resolved.get("registry_entry"):
+        organ_key, entry = resolved["organ_key"], resolved["registry_entry"]
+    else:
+        result = find_repo(registry, repo)
+        if not result:
+            return {"error": f"Repo {repo!r} not found in registry"}
+        organ_key, entry = result
+
+    return {"organ": organ_key, "repo": entry}
+
+
+def registry_list(
+    organ: str | None = None,
+    status: str | None = None,
+    tier: str | None = None,
+    promotion_status: str | None = None,
+    name_contains: str | None = None,
+    public_only: bool = False,
+    platinum_only: bool = False,
+    archived: bool | None = None,
+    sort_by: str = "name",
+    descending: bool = False,
+    registry_path: str | None = None,
+) -> dict[str, Any]:
+    """List repos with optional filters.
+
+    Parameters mirror ``organvm registry list``. Returns a compact
+    projection (name, organ, status, tier, promotion, org) per repo.
+    """
+    from organvm_engine.registry.loader import load_registry
+    from organvm_engine.registry.query import list_repos, sort_repo_results
+
+    registry = load_registry(registry_path)
+    results = list_repos(
+        registry,
+        organ=organ,
+        status=status,
+        tier=tier,
+        public_only=public_only,
+        promotion_status=promotion_status,
+        name_contains=name_contains,
+        platinum_only=platinum_only,
+        archived=archived,
+    )
+    results = sort_repo_results(results, field=sort_by, descending=descending)
+
+    repos = [
+        {
+            "name": entry.get("name", ""),
+            "organ": organ_key,
+            "status": entry.get("implementation_status", ""),
+            "tier": entry.get("tier", ""),
+            "promotion": entry.get("promotion_status", ""),
+            "org": entry.get("org", ""),
+        }
+        for organ_key, entry in results
+    ]
+    return {"total": len(repos), "repos": repos}
+
+
+def registry_search(
+    query: str,
+    fields: list[str] | None = None,
+    case_sensitive: bool = False,
+    exact: bool = False,
+    limit: int | None = None,
+    organ: str | None = None,
+    status: str | None = None,
+    tier: str | None = None,
+    public_only: bool = False,
+    promotion_status: str | None = None,
+    registry_path: str | None = None,
+) -> dict[str, Any]:
+    """Search repositories by text query across selected fields.
+
+    Parameters mirror ``organvm registry search``. Returns matching
+    ``{organ, repo}`` records.
+    """
+    from organvm_engine.registry.loader import load_registry
+    from organvm_engine.registry.query import search_repos
+
+    if not query or not query.strip():
+        return {"error": "query is required"}
+
+    registry = load_registry(registry_path)
+    results = search_repos(
+        registry,
+        query=query,
+        fields=fields,
+        case_sensitive=case_sensitive,
+        exact=exact,
+        limit=limit,
+        organ=organ,
+        status=status,
+        tier=tier,
+        public_only=public_only,
+        promotion_status=promotion_status,
+    )
+    matches = [{"organ": organ_key, "repo": entry} for organ_key, entry in results]
+    return {"total": len(matches), "matches": matches}
+
+
+def registry_stats(registry_path: str | None = None) -> dict[str, Any]:
+    """Return registry-wide statistics (counts by organ/status/tier/promotion)."""
+    from organvm_engine.registry.loader import load_registry
+    from organvm_engine.registry.query import summarize_registry
+
+    registry = load_registry(registry_path)
+    return summarize_registry(registry).to_dict()
+
+
+def registry_deps(
+    repo: str,
+    reverse: bool = False,
+    both: bool = False,
+    transitive: bool = False,
+    max_depth: int | None = None,
+    registry_path: str | None = None,
+) -> dict[str, Any]:
+    """Return dependency and/or dependent edges for a repo.
+
+    Parameters
+    ----------
+    repo:
+        Repository name.
+    reverse:
+        Return dependents (who depends on this) instead of dependencies.
+    both:
+        Return both dependencies and dependents.
+    transitive:
+        Follow edges transitively rather than direct-only.
+    max_depth:
+        Cap transitive traversal depth.
+    registry_path:
+        Optional registry path.
+    """
+    from organvm_engine.registry.loader import load_registry
+    from organvm_engine.registry.query import (
+        find_repo,
+        get_repo_dependencies,
+        get_repo_dependents,
+    )
+
+    registry = load_registry(registry_path)
+    if not find_repo(registry, repo):
+        return {"error": f"Repo {repo!r} not found in registry"}
+
+    payload: dict[str, Any] = {"repo": repo}
+    if both or not reverse:
+        payload["dependencies"] = get_repo_dependencies(
+            registry, repo, transitive=transitive, max_depth=max_depth,
+        )
+    if both or reverse:
+        payload["dependents"] = get_repo_dependents(
+            registry, repo, transitive=transitive, max_depth=max_depth,
+        )
+    return payload
+
+
+def registry_validate(registry_path: str | None = None) -> dict[str, Any]:
+    """Validate registry schema/integrity. Returns errors, warnings, pass flag."""
+    from organvm_engine.registry.loader import load_registry
+    from organvm_engine.registry.validator import validate_registry
+
+    registry = load_registry(registry_path)
+    result = validate_registry(registry)
+    return {
+        "passed": result.passed,
+        "total_repos": result.total_repos,
+        "errors": result.errors,
+        "warnings": result.warnings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# governance
+# ---------------------------------------------------------------------------
+
+
+def governance_audit(
+    registry_path: str | None = None,
+    rules_path: str | None = None,
+) -> dict[str, Any]:
+    """Run the full governance audit.
+
+    Returns critical/warnings/info issue lists and an overall pass flag.
+    """
+    from organvm_engine.governance.audit import run_audit
+    from organvm_engine.governance.rules import load_governance_rules
+    from organvm_engine.registry.loader import load_registry
+
+    registry = load_registry(registry_path)
+    rules = load_governance_rules(rules_path) if rules_path else None
+    result = run_audit(registry, rules)
+    return {
+        "passed": result.passed,
+        "critical": result.critical,
+        "warnings": result.warnings,
+        "info": result.info,
+    }
+
+
+def governance_check_deps(registry_path: str | None = None) -> dict[str, Any]:
+    """Validate the dependency graph (missing targets, cycles, back-edges)."""
+    from organvm_engine.governance.dependency_graph import validate_dependencies
+    from organvm_engine.registry.loader import load_registry
+
+    registry = load_registry(registry_path)
+    result = validate_dependencies(registry)
+    return {
+        "passed": result.passed,
+        "total_edges": result.total_edges,
+        "missing_targets": [list(t) for t in result.missing_targets],
+        "self_deps": result.self_deps,
+        "back_edges": [list(e) for e in result.back_edges],
+        "cycles": result.cycles,
+        "cross_organ": result.cross_organ,
+        "violations": result.violations,
+    }
+
+
+def governance_impact(
+    repo: str,
+    registry_path: str | None = None,
+    workspace: str | None = None,
+) -> dict[str, Any]:
+    """Return the downstream blast radius for a change to ``repo``."""
+    from organvm_engine.governance.impact import calculate_impact
+    from organvm_engine.registry.loader import load_registry
+
+    registry = load_registry(registry_path)
+    report = calculate_impact(repo, registry, workspace)
+    return {
+        "source_repo": report.source_repo,
+        "affected_repos": sorted(report.affected_repos),
+        "affected_count": len(report.affected_repos),
+        "impact_graph": report.impact_graph,
+    }
+
+
+# ---------------------------------------------------------------------------
+# seed
+# ---------------------------------------------------------------------------
+
+
+def seed_discover(workspace: str | None = None) -> dict[str, Any]:
+    """List discovered seed.yaml files as ``org/repo`` identities."""
+    from organvm_engine.seed.discover import discover_seeds
+
+    seeds = discover_seeds(workspace)
+    found = []
+    for path in seeds:
+        parts = path.parts
+        found.append({"org": parts[-3], "repo": parts[-2], "path": str(path)})
+    return {"total": len(found), "seeds": found}
+
+
+def seed_validate(workspace: str | None = None) -> dict[str, Any]:
+    """Validate that every seed.yaml has the required top-level fields."""
+    from organvm_engine.seed.discover import discover_seeds
+    from organvm_engine.seed.reader import read_seed
+
+    required = ["schema_version", "organ", "repo", "org"]
+    seeds = discover_seeds(workspace)
+    results: list[dict[str, Any]] = []
+    failed = 0
+    for path in seeds:
+        try:
+            seed = read_seed(path)
+            missing = [f for f in required if f not in seed]
+            if missing:
+                failed += 1
+                results.append(
+                    {"path": str(path), "passed": False, "missing": missing},
+                )
+            else:
+                results.append(
+                    {
+                        "path": str(path),
+                        "passed": True,
+                        "org": seed.get("org"),
+                        "repo": seed.get("repo"),
+                    },
+                )
+        except Exception as e:  # noqa: BLE001 — surface parse errors as data
+            failed += 1
+            results.append({"path": str(path), "passed": False, "error": str(e)})
+
+    return {
+        "total": len(seeds),
+        "passed": len(seeds) - failed,
+        "failed": failed,
+        "results": results,
+    }
+
+
+def seed_graph(workspace: str | None = None) -> dict[str, Any]:
+    """Build the produces/consumes graph across all seeds."""
+    from organvm_engine.seed.graph import build_seed_graph
+
+    graph = build_seed_graph(workspace)
+    return {
+        "nodes": graph.nodes,
+        "node_count": len(graph.nodes),
+        "edges": [
+            {"source": src, "target": tgt, "type": artifact_type}
+            for src, tgt, artifact_type in graph.edges
+        ],
+        "edge_count": len(graph.edges),
+        "errors": graph.errors,
+    }
+
+
+# ---------------------------------------------------------------------------
+# metrics
+# ---------------------------------------------------------------------------
+
+
+def metrics_calculate(
+    registry_path: str | None = None,
+    workspace: str | None = None,
+) -> dict[str, Any]:
+    """Compute system-wide metrics from the registry.
+
+    Read-only: computes and returns metrics without writing
+    system-metrics.json or mutating the registry.
+    """
+    from pathlib import Path
+
+    from organvm_engine.metrics.calculator import compute_metrics
+    from organvm_engine.registry.loader import load_registry
+
+    registry = load_registry(registry_path)
+    ws = Path(workspace) if workspace else None
+    return compute_metrics(registry, workspace=ws)
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+
+
+def dispatch_validate(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate a dispatch event payload.
+
+    Parameters
+    ----------
+    payload:
+        The event payload object to validate against the dispatch schema.
+    """
+    from organvm_engine.dispatch.payload import validate_payload
+
+    if not isinstance(payload, dict):
+        return {"valid": False, "errors": ["payload must be a JSON object"]}
+
+    ok, errors = validate_payload(payload)
+    return {"valid": ok, "errors": errors}

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,270 @@
+"""Tests for the MCP tool wrappers over the five core organvm CLIs (LIMEN-060).
+
+Every tool returns a JSON-serializable dict and is read-only. Registry-backed
+tools run against the minimal fixture; seed tools run against a synthetic
+workspace under tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from organvm_engine.mcp import (
+    MCP_TOOLS,
+    TOOLS_BY_NAME,
+    call_tool,
+    list_tools,
+)
+from organvm_engine.mcp import tools
+
+FIXTURES = Path(__file__).parent / "fixtures"
+REGISTRY = str(FIXTURES / "registry-minimal.json")
+RULES = str(FIXTURES / "governance-rules-test.json")
+
+
+def _assert_serializable(result: object) -> None:
+    assert isinstance(json.dumps(result), str)
+
+
+# ---------------------------------------------------------------------------
+# manifest / dispatch layer
+# ---------------------------------------------------------------------------
+
+
+class TestManifest:
+    def test_lists_all_five_clis(self):
+        clis = {spec.cli for spec in MCP_TOOLS}
+        assert clis == {"registry", "governance", "seed", "metrics", "dispatch"}
+
+    def test_list_tools_serializable(self):
+        manifest = list_tools()
+        _assert_serializable(manifest)
+        assert len(manifest) == len(MCP_TOOLS)
+        for entry in manifest:
+            assert set(entry) == {"name", "cli", "description"}
+
+    def test_names_unique(self):
+        names = [spec.name for spec in MCP_TOOLS]
+        assert len(names) == len(set(names))
+        assert set(names) == set(TOOLS_BY_NAME)
+
+    def test_handlers_callable(self):
+        for spec in MCP_TOOLS:
+            assert callable(spec.handler)
+
+    def test_call_tool_dispatches(self):
+        result = call_tool("registry_stats", registry_path=REGISTRY)
+        assert result["total_repos"] > 0
+
+    def test_call_tool_unknown_name(self):
+        result = call_tool("does_not_exist")
+        assert "error" in result
+        assert "does_not_exist" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_show_found(self):
+        result = tools.registry_show("recursive-engine", registry_path=REGISTRY)
+        _assert_serializable(result)
+        assert result["repo"]["name"] == "recursive-engine"
+        assert result["organ"] == "ORGAN-I"
+
+    def test_show_not_found(self):
+        result = tools.registry_show("nope-not-here", registry_path=REGISTRY)
+        assert "error" in result
+
+    def test_list_all(self):
+        result = tools.registry_list(registry_path=REGISTRY)
+        _assert_serializable(result)
+        assert result["total"] == len(result["repos"])
+        assert result["total"] >= 3
+
+    def test_list_filter_by_organ(self):
+        result = tools.registry_list(organ="ORGAN-I", registry_path=REGISTRY)
+        assert result["total"] >= 1
+        assert all(r["organ"] == "ORGAN-I" for r in result["repos"])
+
+    def test_list_filter_by_tier(self):
+        result = tools.registry_list(tier="flagship", registry_path=REGISTRY)
+        assert all(r["tier"] == "flagship" for r in result["repos"])
+
+    def test_search_found(self):
+        result = tools.registry_search("recursive", registry_path=REGISTRY)
+        _assert_serializable(result)
+        assert result["total"] >= 1
+        names = {m["repo"]["name"] for m in result["matches"]}
+        assert "recursive-engine" in names
+
+    def test_search_empty_query(self):
+        result = tools.registry_search("  ", registry_path=REGISTRY)
+        assert "error" in result
+
+    def test_stats(self):
+        result = tools.registry_stats(registry_path=REGISTRY)
+        _assert_serializable(result)
+        assert "by_organ" in result
+        assert result["total_repos"] > 0
+
+    def test_deps_dependencies(self):
+        result = tools.registry_deps("ontological-framework", registry_path=REGISTRY)
+        _assert_serializable(result)
+        assert "dependencies" in result
+        assert "recursive-engine" in result["dependencies"]
+
+    def test_deps_reverse(self):
+        result = tools.registry_deps(
+            "recursive-engine", reverse=True, registry_path=REGISTRY,
+        )
+        assert "dependents" in result
+        assert "dependencies" not in result
+
+    def test_deps_both(self):
+        result = tools.registry_deps(
+            "recursive-engine", both=True, registry_path=REGISTRY,
+        )
+        assert "dependencies" in result
+        assert "dependents" in result
+
+    def test_deps_unknown_repo(self):
+        result = tools.registry_deps("ghost", registry_path=REGISTRY)
+        assert "error" in result
+
+    def test_validate(self):
+        result = tools.registry_validate(registry_path=REGISTRY)
+        _assert_serializable(result)
+        assert "passed" in result
+        assert isinstance(result["errors"], list)
+        assert result["total_repos"] > 0
+
+
+# ---------------------------------------------------------------------------
+# governance
+# ---------------------------------------------------------------------------
+
+
+class TestGovernance:
+    def test_audit(self):
+        result = tools.governance_audit(registry_path=REGISTRY, rules_path=RULES)
+        _assert_serializable(result)
+        assert "passed" in result
+        assert isinstance(result["critical"], list)
+        assert isinstance(result["warnings"], list)
+        assert isinstance(result["info"], list)
+
+    def test_check_deps(self):
+        result = tools.governance_check_deps(registry_path=REGISTRY)
+        _assert_serializable(result)
+        assert "passed" in result
+        assert "total_edges" in result
+        assert isinstance(result["cycles"], list)
+
+    def test_impact(self):
+        result = tools.governance_impact(
+            "recursive-engine", registry_path=REGISTRY,
+        )
+        _assert_serializable(result)
+        assert result["source_repo"] == "recursive-engine"
+        assert "affected_repos" in result
+        # ontological-framework and metasystem-master both depend on it
+        assert "ontological-framework" in result["affected_repos"]
+        assert result["affected_count"] == len(result["affected_repos"])
+
+
+# ---------------------------------------------------------------------------
+# seed
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def seed_workspace(tmp_path):
+    """A synthetic workspace with one valid and one invalid seed.yaml."""
+    valid_dir = tmp_path / "organvm-i-theoria" / "recursive-engine"
+    valid_dir.mkdir(parents=True)
+    (valid_dir / "seed.yaml").write_text(
+        'schema_version: "1.0"\norgan: I\nrepo: recursive-engine\n'
+        "org: organvm-i-theoria\n",
+    )
+
+    bad_dir = tmp_path / "organvm-i-theoria" / "broken-repo"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "seed.yaml").write_text('repo: broken-repo\norg: organvm-i-theoria\n')
+
+    return tmp_path
+
+
+class TestSeed:
+    def test_discover(self, seed_workspace):
+        result = tools.seed_discover(workspace=str(seed_workspace))
+        _assert_serializable(result)
+        assert result["total"] == 2
+        repos = {s["repo"] for s in result["seeds"]}
+        assert repos == {"recursive-engine", "broken-repo"}
+
+    def test_discover_empty(self, tmp_path):
+        result = tools.seed_discover(workspace=str(tmp_path))
+        assert result["total"] == 0
+        assert result["seeds"] == []
+
+    def test_validate(self, seed_workspace):
+        result = tools.seed_validate(workspace=str(seed_workspace))
+        _assert_serializable(result)
+        assert result["total"] == 2
+        assert result["passed"] == 1
+        assert result["failed"] == 1
+        bad = next(r for r in result["results"] if not r["passed"])
+        assert "schema_version" in bad["missing"]
+        assert "organ" in bad["missing"]
+
+    def test_graph(self, seed_workspace):
+        result = tools.seed_graph(workspace=str(seed_workspace))
+        _assert_serializable(result)
+        assert "nodes" in result
+        assert "edges" in result
+        assert result["edge_count"] == len(result["edges"])
+
+
+# ---------------------------------------------------------------------------
+# metrics
+# ---------------------------------------------------------------------------
+
+
+class TestMetrics:
+    def test_calculate(self):
+        result = tools.metrics_calculate(registry_path=REGISTRY)
+        _assert_serializable(result)
+        assert "total_repos" in result
+        assert "total_organs" in result
+        assert result["total_repos"] > 0
+
+    def test_calculate_read_only(self, tmp_path):
+        """Computing metrics must not write system-metrics.json."""
+        before = set(tmp_path.iterdir())
+        tools.metrics_calculate(registry_path=REGISTRY, workspace=str(tmp_path))
+        assert set(tmp_path.iterdir()) == before
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    def test_validate_invalid_type(self):
+        result = tools.dispatch_validate(payload="not a dict")  # type: ignore[arg-type]
+        assert result["valid"] is False
+        assert result["errors"]
+
+    def test_validate_returns_structure(self):
+        result = tools.dispatch_validate(payload={})
+        _assert_serializable(result)
+        assert "valid" in result
+        assert "errors" in result
+        assert isinstance(result["errors"], list)


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-060`.

Audited 2026-06-01 from Jules-ready batch. feat: implement MCP tool wrappers for all 5 organvm CLIs

Refs: https://github.com/a-organvm/organvm-engine/issues/89, https://jules.google.com/session/11094992051730985281

_Produced in an isolated worktree off origin — review before merge._