### PR TITLE
[limen LIMEN-062] Add --format json flag to organvm registry list command

### DIFF
--- a/src/organvm_engine/cli/__init__.py
+++ b/src/organvm_engine/cli/__init__.py
@@ -3,7 +3,7 @@
 Usage:
     organvm status
     organvm registry show <repo>
-    organvm registry list [--organ X] [--status X] [--tier X]
+    organvm registry list [--organ X] [--status X] [--tier X] [--format json]
     organvm registry search <query> [--field X] [--exact]
     organvm registry deps <repo> [--reverse] [--transitive]
     organvm registry stats [--json]
@@ -357,6 +357,12 @@ def build_parser() -> argparse.ArgumentParser:
     ls_archived = ls.add_mutually_exclusive_group()
     ls_archived.add_argument("--archived", action="store_true")
     ls_archived.add_argument("--unarchived", action="store_true")
+    ls.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format",
+    )
     ls.add_argument("--json", action="store_true", help="Output JSON")
 
     search = reg_sub.add_parser("search", help="Search repos by text query")

--- a/src/organvm_engine/cli/registry.py
+++ b/src/organvm_engine/cli/registry.py
@@ -84,7 +84,7 @@ def cmd_registry_list(args: argparse.Namespace) -> int:
     )
     results = sort_repo_results(results, field=args.sort_by, descending=args.desc)
 
-    if args.json:
+    if getattr(args, "json", False) or getattr(args, "format", "table") == "json":
         payload = [
             {
                 "name": repo["name"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,6 +256,31 @@ class TestRegistryCommands:
         for key in ("name", "organ", "status", "tier", "promotion", "org"):
             assert key in entry, f"Missing key: {key}"
 
+    def test_registry_list_format_json(self, capsys):
+        with patch(
+            "sys.argv",
+            [
+                "organvm",
+                "--registry",
+                MOCK_REGISTRY,
+                "registry",
+                "list",
+                "--organ",
+                "META",
+                "--format",
+                "json",
+            ],
+        ):
+            rc = main()
+        assert rc == 0
+        import json
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert len(data) == 2
+        assert all(entry["organ"] == "META-ORGANVM" for entry in data)
+        assert "Name" not in out
+
     def test_registry_list_json_with_organ_filter(self, capsys):
         with patch(
             "sys.argv",
@@ -288,6 +313,11 @@ class TestRegistryCommands:
         parser = build_parser()
         args = parser.parse_args(["registry", "list", "--json"])
         assert args.json is True
+
+    def test_registry_list_format_json_flag_parses(self):
+        parser = build_parser()
+        args = parser.parse_args(["registry", "list", "--format", "json"])
+        assert args.format == "json"
 
     def test_registry_validate_passes(self, capsys):
         with patch("sys.argv", ["organvm", "--registry", MOCK_REGISTRY, "registry", "validate"]):


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-062`.

Audited 2026-06-01 from Jules-ready batch. Add --format json flag to organvm registry list command

Refs: https://github.com/a-organvm/organvm-engine/issues/83

_Produced in an isolated worktree off origin — review before merge._