### PR TITLE
[limen LIMEN-068] fix(irf): stats command undercounts newly added tail items

### DIFF
--- a/src/organvm_engine/irf/parser.py
+++ b/src/organvm_engine/irf/parser.py
@@ -112,15 +112,20 @@ def _extract_domain(item_id: str) -> str:
 
 
 def _parse_active_row(cells: list[str], status: str, section: str) -> IRFItem | None:
-    """Parse a 6-column active item row.
+    """Parse an active item row.
 
-    Expected columns: ID | Priority | Action | Owner | Source | Blocker
+    Expected columns: ID | Priority | Action | Owner | Source | Blocker.
+    Hand-appended tail rows sometimes stop after the Action cell; owner,
+    source, and blocker are optional for parse/stat purposes.
     """
-    if len(cells) < 6:
+    if len(cells) < 3:
         return None
-    raw_item_id, raw_priority, action, owner, source, blocker = (
-        cells[0], cells[1], cells[2], cells[3], cells[4], cells[5],
-    )
+    raw_item_id = cells[0]
+    raw_priority = cells[1]
+    action = cells[2]
+    owner = cells[3] if len(cells) > 3 else ""
+    source = cells[4] if len(cells) > 4 else ""
+    blocker = cells[5] if len(cells) > 5 else ""
     item_id = _strip_cell_markup(raw_item_id)
     priority = _clean_priority(raw_priority)
     # ID must look like IRF-XXX-NNN[a] or DONE-NNN[a]

--- a/tests/test_irf_writer.py
+++ b/tests/test_irf_writer.py
@@ -73,6 +73,21 @@ def test_row_without_trailing_pipe_parses():
     assert "IRF-SYS-096" in _ids(CASES)
 
 
+def test_short_active_row_keeps_priority_and_action():
+    """Tail-added active rows may omit owner/source/blocker cells."""
+    items = {i.id: i for i in parse_irf(CASES)}
+    item = items["IRF-SYS-096"]
+    assert item.status == "open"
+    assert item.priority == "P2"
+    assert "Row without trailing pipe" in item.action
+
+
+def test_stats_count_short_tail_row_priority():
+    """Category E rows must contribute to priority stats, not just total."""
+    stats = irf_stats(parse_irf(CASES))
+    assert stats["by_priority"]["P2"] == 2
+
+
 def test_late_file_row_resolves():
     """IRF-OPS-088 — rows late in the file are reachable."""
     assert "IRF-OPS-087" in _ids(CASES)


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-068`.

Audited 2026-06-01 from Jules-ready batch. fix(irf): stats command undercounts newly added tail items

Refs: https://github.com/a-organvm/organvm-engine/issues/71

_Produced in an isolated worktree off origin — review before merge._