### PR TITLE
[limen CIFIX-a-organvm-organvm-engine] Fix pre-existing CI breakage (tsc/test-matrix errors) blocking all open PRs in a-organvm/organvm-engine

### DIFF
--- a/src/organvm_engine/cli/cmd_pulse.py
+++ b/src/organvm_engine/cli/cmd_pulse.py
@@ -760,7 +760,7 @@ def cmd_pulse_ammoi(args: Namespace) -> int:
         if ammoi.density_delta_7d is not None:
             s = "+" if ammoi.density_delta_7d > 0 else ""
             print(f"     Δ7d:  {s}{ammoi.density_delta_7d:.1%}")
-        if getattr(ammoi, 'density_delta_30d', None) is not None:
+        if ammoi.density_delta_30d is not None:
             s = "+" if ammoi.density_delta_30d > 0 else ""
             print(f"     Δ30d: {s}{ammoi.density_delta_30d:.1%}")
 


### PR DESCRIPTION
Autonomous **limen** dispatch of task `CIFIX-a-organvm-organvm-engine`.

Fix the FAILING CI checks on the default branch of a-organvm/organvm-engine so its open PRs become mergeable. Failing checks: test-matrix, test, CLAssistant (CLA sign-off). These are PRE-EXISTING breakage on the base branch (config/deps/types), NOT the PRs' code — fix the root cause minimally so each listed check goes green. Open ONE fix PR.

_Produced in an isolated worktree off origin — review before merge._