### PR TITLE
[limen HEAL-cifix-organvm-organvm-engine-127] fix failing CI on organvm/organvm-engine#127

### DIFF
--- a/logs/agents/opencode.json
+++ b/logs/agents/opencode.json
@@ -2,10 +2,10 @@
   "agent": "opencode",
   "status": "idle",
   "accepting_tasks": true,
-  "available_tokens": 38469317,
-  "available_pct": 76.9,
-  "current_task_id": "HEAL-cifix-organvm-organvm-engine-115",
-  "heartbeat": "2026-07-06T03:38:27.964482+00:00",
-  "token_usage_pct": 23.06,
+  "available_tokens": 36933476,
+  "available_pct": 73.9,
+  "current_task_id": "HEAL-cifix-organvm-organvm-engine-127",
+  "heartbeat": "2026-07-06T04:00:45.045760+00:00",
+  "token_usage_pct": 26.13,
   "clock_health": "ok"
 }


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-organvm-engine-127`.

PR organvm/organvm-engine#127 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/organvm-engine/pull/127 [auto-emitted 2026-07-04 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/organvm-engine/pull/127

_Produced in an isolated worktree off origin — review before merge._