### PR TITLE
[limen HEAL-cifix-organvm-organvm-engine-135] fix failing CI on organvm/organvm-engine#135

### DIFF
--- a/logs/agents/opencode.json
+++ b/logs/agents/opencode.json
@@ -2,10 +2,10 @@
   "agent": "opencode",
   "status": "idle",
   "accepting_tasks": true,
-  "available_tokens": 31128440,
-  "available_pct": 62.3,
-  "current_task_id": "HEAL-cifix-organvm-organvm-engine-130",
-  "heartbeat": "2026-07-06T07:14:01.445281+00:00",
-  "token_usage_pct": 37.74,
+  "available_tokens": 31100505,
+  "available_pct": 62.2,
+  "current_task_id": "HEAL-cifix-organvm-organvm-engine-135",
+  "heartbeat": "2026-07-06T07:33:32.664577+00:00",
+  "token_usage_pct": 37.8,
   "clock_health": "ok"
 }


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-organvm-engine-135`.

PR organvm/organvm-engine#135 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/organvm-engine/pull/135 [auto-emitted 2026-07-04 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/organvm-engine/pull/135

_Produced in an isolated worktree off origin — review before merge._