### PR TITLE
[limen HEAL-cifix-organvm-organvm-engine-137] fix failing CI on organvm/organvm-engine#137

### DIFF
--- a/logs/agents/opencode.json
+++ b/logs/agents/opencode.json
@@ -2,10 +2,10 @@
   "agent": "opencode",
   "status": "idle",
   "accepting_tasks": true,
-  "available_tokens": 31100505,
-  "available_pct": 62.2,
-  "current_task_id": "HEAL-cifix-organvm-organvm-engine-135",
-  "heartbeat": "2026-07-06T07:33:32.664577+00:00",
-  "token_usage_pct": 37.8,
+  "available_tokens": 31011839,
+  "available_pct": 62.0,
+  "current_task_id": "HEAL-cifix-organvm-organvm-engine-137",
+  "heartbeat": "2026-07-06T07:38:28.002672+00:00",
+  "token_usage_pct": 37.98,
   "clock_health": "ok"
 }


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-organvm-engine-137`.

PR organvm/organvm-engine#137 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/organvm-engine/pull/137 [auto-emitted 2026-07-04 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/organvm-engine/pull/137

_Produced in an isolated worktree off origin — review before merge._