### PR TITLE
[limen HEAL-cifix-organvm-organvm-engine-143] fix failing CI on organvm/organvm-engine#143

### DIFF
--- a/logs/agents/opencode.json
+++ b/logs/agents/opencode.json
@@ -2,10 +2,10 @@
   "agent": "opencode",
   "status": "idle",
   "accepting_tasks": true,
-  "available_tokens": 27891594,
-  "available_pct": 55.8,
-  "current_task_id": "HEAL-cifix-organvm-organvm-engine-136",
-  "heartbeat": "2026-07-06T08:01:43.414832+00:00",
-  "token_usage_pct": 44.22,
+  "available_tokens": 27844035,
+  "available_pct": 55.7,
+  "current_task_id": "HEAL-cifix-organvm-organvm-engine-143",
+  "heartbeat": "2026-07-06T08:34:47.531274+00:00",
+  "token_usage_pct": 44.31,
   "clock_health": "ok"
 }


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-organvm-engine-143`.

PR organvm/organvm-engine#143 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/organvm-engine/pull/143 [auto-emitted 2026-07-04 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/organvm-engine/pull/143

_Produced in an isolated worktree off origin — review before merge._