### PR TITLE
[limen HEAL-cifix-organvm-organvm-engine-113] fix failing CI on organvm/organvm-engine#113

### DIFF
--- a/src/organvm_engine/ci/protect.py
+++ b/src/organvm_engine/ci/protect.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 
+from organvm_engine.ci.audit import _is_docs_only
+
 
 @dataclass
 class ProtectionPayload:
@@ -50,7 +52,10 @@ class ProtectionPayload:
 
     def to_gh_command(self) -> str:
         """Generate the full ``gh api`` command string."""
-        endpoint = f"repos/{self.org}/{self.repo_name}/branches/{self.branch}/protection"
+        endpoint = (
+            f"repos/{self.org}/{self.repo_name}/"
+            f"branches/{self.branch}/protection"
+        )
         payload_json = json.dumps(self.to_api_json(), indent=2)
         return (
             f"gh api -X PUT \"{endpoint}\" "
@@ -58,11 +63,15 @@ class ProtectionPayload:
         )
 
     def to_dict(self) -> dict:
+        endpoint = (
+            f"repos/{self.org}/{self.repo_name}/"
+            f"branches/{self.branch}/protection"
+        )
         return {
             "org": self.org,
             "repo": self.repo_name,
             "branch": self.branch,
-            "endpoint": f"repos/{self.org}/{self.repo_name}/branches/{self.branch}/protection",
+            "endpoint": endpoint,
             "payload": self.to_api_json(),
             "command": self.to_gh_command(),
         }
@@ -177,6 +186,14 @@ def plan_branch_protection(
                 plan.skipped.append({
                     "repo": f"{org_name}/{repo_name}",
                     "reason": "archived",
+                })
+                continue
+
+            # Skip docs-only repos
+            if _is_docs_only(repo_name, None):
+                plan.skipped.append({
+                    "repo": f"{org_name}/{repo_name}",
+                    "reason": "docs-only",
                 })
                 continue
 

--- a/tests/test_ci_protect.py
+++ b/tests/test_ci_protect.py
@@ -123,6 +123,22 @@ class TestPlanBranchProtection:
         assert "local-repo" not in repo_names
         assert "candidate-repo" not in repo_names
 
+    def test_docs_only_repos_are_skipped(self, registry_with_graduated):
+        # Add a docs-only repo to the registry
+        registry_with_graduated["organs"]["ORGAN-I"]["repositories"].append({
+            "name": ".github",
+            "org": "organvm-i-theoria",
+            "promotion_status": "GRADUATED",
+            "tier": "standard",
+        })
+        plan = plan_branch_protection(registry_with_graduated)
+
+        repo_names = {p.repo_name for p in plan.repos}
+        assert ".github" not in repo_names
+
+        skip_reasons = {s["repo"]: s["reason"] for s in plan.skipped}
+        assert skip_reasons.get("organvm-i-theoria/.github") == "docs-only"
+
     def test_already_protected_repos_excluded(self, registry_with_graduated):
         plan = plan_branch_protection(registry_with_graduated)
         # organvm-engine is in _ALREADY_PROTECTED


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-organvm-engine-113`.

PR organvm/organvm-engine#113 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/organvm-engine/pull/113 [auto-emitted 2026-07-04 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/organvm-engine/pull/113

_Produced in an isolated worktree off origin — review before merge._