### PR TITLE
feat(bifrons): portal engine — resonance, proposals, contribution pipeline, backflow

### DIFF
--- a/src/organvm_engine/cli/__init__.py
+++ b/src/organvm_engine/cli/__init__.py
@@ -228,6 +228,12 @@ from organvm_engine.cli.plans import (
     cmd_plans_sweep,
     cmd_plans_tidy,
 )
+from organvm_engine.cli.portal import (
+    cmd_portal_convergences,
+    cmd_portal_import_stars,
+    cmd_portal_propose,
+    cmd_portal_status,
+)
 from organvm_engine.cli.primitives import (
     cmd_primitive_guardian_add_watch,
     cmd_primitive_guardian_check,
@@ -2216,6 +2222,32 @@ def build_parser() -> argparse.ArgumentParser:
 
     net_sub.add_parser("suggest", help="Suggest next engagement actions")
 
+    # portal — BIFRONS star<->contribution portal (engine half)
+    portal = sub.add_parser(
+        "portal",
+        help="BIFRONS star<->contribution portal — resonance, proposals, convergence",
+    )
+    portal_sub = portal.add_subparsers(dest="subcommand")
+
+    portal_status = portal_sub.add_parser("status", help="Portal store status")
+    portal_status.add_argument("--db", default=None, help="Portal DB path")
+
+    portal_import = portal_sub.add_parser(
+        "import-stars", help="Compile star dossiers into resonance edges",
+    )
+    portal_import.add_argument("--db", default=None, help="Portal DB path")
+    portal_import.add_argument("--write", action="store_true", help="Persist edges (default)")
+
+    portal_conv = portal_sub.add_parser("convergences", help="Cross-organ convergence points")
+    portal_conv.add_argument("--db", default=None, help="Portal DB path")
+    portal_conv.add_argument("--min-repos", type=int, default=2, dest="min_repos")
+    portal_conv.add_argument("--json", action="store_true", help="Output JSON")
+
+    portal_prop = portal_sub.add_parser("propose", help="Generate a transmutation proposal")
+    portal_prop.add_argument("external", help="External repo (owner/name)")
+    portal_prop.add_argument("target", help="Target ORGANVM repo")
+    portal_prop.add_argument("--db", default=None, help="Portal DB path")
+
     # trivium — dialectica universalis
     trv = sub.add_parser(
         "trivium",
@@ -3544,6 +3576,18 @@ def main() -> int:
         if handler:
             return handler(args)
         parser.parse_args(["network", "--help"])
+        return 0
+    if args.command == "portal":
+        portal_dispatch = {
+            "status": cmd_portal_status,
+            "import-stars": cmd_portal_import_stars,
+            "convergences": cmd_portal_convergences,
+            "propose": cmd_portal_propose,
+        }
+        handler = portal_dispatch.get(getattr(args, "subcommand", "") or "")
+        if handler:
+            return handler(args)
+        parser.parse_args(["portal", "--help"])
         return 0
     if args.command == "trivium":
         trivium_dispatch = {

--- a/src/organvm_engine/cli/portal.py
+++ b/src/organvm_engine/cli/portal.py
@@ -1,0 +1,113 @@
+"""CLI commands for the BIFRONS portal (engine half).
+
+    organvm portal status                       Show portal store counts
+    organvm portal import-stars [--write]       Compile star dossiers -> resonance edges
+    organvm portal convergences [--min-repos N] Cross-organ convergence points
+    organvm portal propose <external> <target>  Generate a transmutation proposal
+
+BIFRONS (Janus, two-faced) is the star<->contribution portal; distinct from
+IANVA (the MCP doorway).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from organvm_engine.network.convergence import convergence_report, find_convergences
+from organvm_engine.network.resonance import InternalRepo
+from organvm_engine.network.star_importer import import_stars
+from organvm_engine.portal import store
+from organvm_engine.portal.proposals import propose_transmutation
+
+
+def _internal_repos_from_registry() -> list[InternalRepo]:
+    """Best-effort ORGANVM repo descriptors from the registry (for mapping)."""
+    try:
+        from organvm_engine.registry.loader import load_registry
+        from organvm_engine.registry.query import list_repos
+
+        registry = load_registry()
+        repos: list[InternalRepo] = []
+        for organ, entry in list_repos(registry):
+            name = entry.get("name") or entry.get("repo") or ""
+            if not name:
+                continue
+            lang = entry.get("language") or entry.get("primary_language") or ""
+            topics = set(entry.get("topics") or [])
+            repos.append(InternalRepo(
+                name=name,
+                organ=str(organ),
+                languages={lang} if lang else set(),
+                topics={t.lower() for t in topics},
+                description=entry.get("description", "") or "",
+            ))
+        return repos
+    except Exception:
+        return []
+
+
+def cmd_portal_status(args: argparse.Namespace) -> int:
+    conn = store.connect(getattr(args, "db", None))
+    store.init_exchange_schema(conn)
+    counts = store.counts(conn)
+    print("BIFRONS PORTAL —")
+    print(f"  db: {getattr(args, 'db', None) or store.default_db_path()}")
+    try:
+        ex = conn.execute(
+            "SELECT state, COUNT(*) n FROM exchange GROUP BY state ORDER BY n DESC",
+        ).fetchall()
+        print("  exchanges by state:")
+        for row in ex:
+            print(f"    {row['state']}: {row['n']}")
+    except Exception:
+        pass
+    for key, val in counts.items():
+        print(f"  {key}: {val}")
+    conn.close()
+    return 0
+
+
+def cmd_portal_import_stars(args: argparse.Namespace) -> int:
+    conn = store.connect(getattr(args, "db", None))
+    internal = _internal_repos_from_registry()
+    print(f"BIFRONS IMPORT-STARS — mapping against {len(internal)} internal repos...")
+    if not internal:
+        print("  (no internal repos resolved from registry; edges will be unresolved)")
+    summary = import_stars(conn, internal)
+    s = summary.as_dict()
+    print(f"  dossiers={s['dossiers']}  edges={s['edges']}  "
+          f"mapped={s['mapped']}  unresolved={s['unresolved']}")
+    conn.close()
+    return 0
+
+
+def cmd_portal_convergences(args: argparse.Namespace) -> int:
+    conn = store.connect(getattr(args, "db", None))
+    min_repos = getattr(args, "min_repos", 2)
+    if getattr(args, "json", False):
+        import json
+        convs = find_convergences(conn, min_repos=min_repos)
+        print(json.dumps([c.as_dict() for c in convs], indent=2))
+    else:
+        print(convergence_report(conn, min_repos=min_repos))
+    conn.close()
+    return 0
+
+
+def cmd_portal_propose(args: argparse.Namespace) -> int:
+    conn = store.connect(getattr(args, "db", None))
+    store.init_exchange_schema(conn)
+    dossier = store.get_dossier(conn, args.external)
+    if dossier is None:
+        print(f"  no dossier for {args.external} — run 'alchemia stars dossier' first.")
+        conn.close()
+        return 1
+    proposal = propose_transmutation(dossier, args.target)
+    store.insert_transmutation_proposal(conn, proposal)
+    print(f"BIFRONS PROPOSE — {proposal.external_repo} -> {proposal.target_repo}")
+    print(f"  class: {proposal.klass}  license: {proposal.license_decision}")
+    print(f"  abstraction: {proposal.abstraction_level}  copied_code: {proposal.copied_code}")
+    print(f"  finding: {proposal.finding}")
+    print(f"  proposed: {proposal.proposed_change}")
+    conn.close()
+    return 0

--- a/src/organvm_engine/contrib/backflow.py
+++ b/src/organvm_engine/contrib/backflow.py
@@ -211,3 +211,63 @@ def write_backflow_manifest(
     manifest_path = output_dir / "backflow-manifest.yaml"
     manifest_path.write_text(yaml.dump(manifest, default_flow_style=False, sort_keys=False))
     return manifest_path
+
+
+# --- BIFRONS: metabolize a portal exchange outcome through the seven organs ---
+_OUTCOME_TO_PR_STATE = {
+    "merged": PRState.MERGED,
+    "declined": PRState.CLOSED,
+    "dormant": PRState.OPEN,
+}
+
+
+def metabolize_exchange(
+    conn,
+    *,
+    exchange_id: str,
+    external_repo: str,
+    outcome: str,
+    title: str = "",
+    target_pr: int | None = None,
+    language: str | None = None,
+) -> list[BackflowSignal]:
+    """Route a BIFRONS exchange outcome through the seven-organ backflow.
+
+    Reuses ``classify_contribution`` (the canonical classifier) rather than
+    reimplementing routing, writes the resulting signals to the portal store,
+    and advances the exchange to BACKFLOW_COMPLETE. Review criticism and rejected
+    contributions are metabolized too — they are inputs, not waste.
+    """
+    from organvm_engine.portal import store
+    from organvm_engine.portal.state_machine import ExchangeState
+
+    repo = ContribRepo(
+        name=external_repo,
+        path=Path(),
+        target_repo=external_repo,
+        target_pr=target_pr,
+        language=language,
+    )
+    status = ContribStatus(
+        repo=repo,
+        state=_OUTCOME_TO_PR_STATE.get(outcome, PRState.UNKNOWN),
+        title=title or f"contribution to {external_repo}",
+    )
+    signals = classify_contribution(status)
+
+    store.init_exchange_schema(conn)
+    for signal in signals:
+        store.insert_backflow_signal(
+            conn,
+            exchange_id=exchange_id,
+            external_repo=external_repo,
+            signal_type=signal.signal_type.value,
+            organ=signal.organ_key,
+            content=signal.content,
+            confidence=signal.confidence,
+        )
+    store.advance_exchange(
+        conn, exchange_id, ExchangeState.BACKFLOW_COMPLETE.value,
+        data={"outcome": outcome, "backflow_signals": len(signals)},
+    )
+    return signals

--- a/src/organvm_engine/contrib/executor.py
+++ b/src/organvm_engine/contrib/executor.py
@@ -1,0 +1,151 @@
+"""Contribution packet assembly + policy-gated submission for BIFRONS.
+
+Produces the contribution packet (everything a maintainer or a human reviewer
+needs to judge the contribution) and, only past the policy gate, performs the
+one external write. The default posture is prepare, never submit.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from organvm_engine.contrib.policy import ContributionPolicy, authorize_submit
+from organvm_engine.contrib.validator import ValidationResult
+from organvm_engine.contrib.worktree import WorkspacePlan
+from organvm_engine.portal import store
+from organvm_engine.portal.models import ContributionCandidate
+from organvm_engine.portal.state_machine import ExchangeState
+
+
+def build_packet(
+    candidate: ContributionCandidate,
+    dossier: dict,
+    workspace: WorkspacePlan,
+    validation: ValidationResult,
+    *,
+    draft_title: str = "",
+    draft_body: str = "",
+) -> dict:
+    """Assemble the contribution packet — prepared, never sent by this call."""
+    contracts = dossier.get("contracts", {})
+    return {
+        "external_repo": candidate.external_repo,
+        "source_ref": workspace.ref,
+        "kind": candidate.kind,
+        "rationale": candidate.rationale,
+        "reproduction": validation.reproduction,
+        "check_commands": validation.commands,
+        "contribution_policy": {
+            "contributing": contracts.get("contributing", ""),
+            "security": contracts.get("security", ""),
+            "cla_or_dco": contracts.get("cla_or_dco", "unknown"),
+        },
+        "license_state": contracts.get("license", {}),
+        "workspace": workspace.as_dict(),
+        "draft_pr": {
+            "title": draft_title or f"{candidate.kind}: contribution from ORGANVM",
+            "body": draft_body or candidate.rationale,
+        },
+        "relationship": {"exchange_id": candidate.exchange_id},
+        "default_posture": "prepared-not-submitted",
+    }
+
+
+def prepare(
+    conn: sqlite3.Connection,
+    candidate: ContributionCandidate,
+    packet: dict,
+) -> None:
+    """Record the packet on the candidate and walk the exchange to PATCH_PREPARED."""
+    store.init_exchange_schema(conn)
+    conn.execute(
+        "UPDATE contribution_candidate SET packet_json=?, status='prepared' "
+        "WHERE exchange_id=? AND external_repo=?",
+        (_dumps(packet), candidate.exchange_id, candidate.external_repo),
+    )
+    conn.commit()
+    for state in (
+        ExchangeState.UPSTREAM_POLICY_CHECKED,
+        ExchangeState.REPRODUCED,
+        ExchangeState.PATCH_PREPARED,
+    ):
+        store.advance_exchange(conn, candidate.exchange_id, state.value)
+
+
+def submit(
+    conn: sqlite3.Connection,
+    policy: ContributionPolicy,
+    candidate: ContributionCandidate,
+    packet: dict,
+    *,
+    human_approved: bool = False,
+    checks_passing: bool = False,
+    duplicate_exists: bool = False,
+    open_prs: int = 0,
+    maintainer_opt_out: bool = False,
+    execute: bool = False,
+) -> dict:
+    """The external-write boundary. Returns the decision; submits only if allowed+executed."""
+    decision = authorize_submit(
+        policy,
+        external_repo=candidate.external_repo,
+        kind=candidate.kind,
+        human_approved=human_approved,
+        checks_passing=checks_passing,
+        duplicate_exists=duplicate_exists,
+        open_prs=open_prs,
+        maintainer_opt_out=maintainer_opt_out,
+    )
+    result = {
+        "external_repo": candidate.external_repo,
+        "allowed": decision.allowed,
+        "reason": decision.reason,
+        "requires_human": decision.requires_human,
+        "submitted": False,
+    }
+    if not decision.allowed:
+        return result
+
+    # Authorized. Walk HUMAN_APPROVED; only actually open the PR when executed.
+    store.advance_exchange(conn, candidate.exchange_id, ExchangeState.HUMAN_APPROVED.value)
+    if not execute:
+        result["reason"] = "authorized but not executed (dry-run)"
+        return result
+
+    number = _open_pr(candidate.external_repo, packet)
+    conn.execute(
+        "INSERT INTO upstream_interaction(exchange_id, external_repo, kind, number, "
+        "url, state, review_decision, created_at, updated_at) "
+        "VALUES(?,?,?,?,?,?,?,?,?)",
+        (candidate.exchange_id, candidate.external_repo, "pr", number,
+         f"https://github.com/{candidate.external_repo}/pull/{number}", "open", "",
+         store.now_iso(), store.now_iso()),
+    )
+    conn.commit()
+    store.advance_exchange(
+        conn, candidate.exchange_id, ExchangeState.UPSTREAM_SUBMITTED.value,
+        data={"upstream_pr": number},
+    )
+    result["submitted"] = True
+    result["pr_number"] = number
+    return result
+
+
+def _open_pr(external_repo: str, packet: dict) -> int:  # pragma: no cover - external write
+    """Open the upstream PR via gh (only reached under execute=True + policy pass)."""
+    import json
+    import subprocess
+
+    title = packet["draft_pr"]["title"]
+    body = packet["draft_pr"]["body"]
+    out = subprocess.run(
+        ["gh", "pr", "create", "--repo", external_repo, "--title", title,
+         "--body", body, "--json", "number"],
+        capture_output=True, text=True, check=True,
+    )
+    return int(json.loads(out.stdout).get("number", 0))
+
+
+def _dumps(obj: dict) -> str:
+    import json
+    return json.dumps(obj)

--- a/src/organvm_engine/contrib/planner.py
+++ b/src/organvm_engine/contrib/planner.py
@@ -1,0 +1,65 @@
+"""Contribution opportunity planning for BIFRONS.
+
+A contribution candidate is generated only when ORGANVM holds real evidence — a
+reproducible defect, a confirmed documentation ambiguity, a missing test, a
+compatibility problem discovered while integrating, a measured improvement, an
+interoperability adapter, or a narrowly-scoped, locally-validated feature.
+
+Candidates are recorded and the exchange advanced; nothing is submitted here.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from organvm_engine.network.resonance import contribution_score
+from organvm_engine.portal import store
+from organvm_engine.portal.models import CONTRIBUTION_KINDS, ContributionCandidate
+from organvm_engine.portal.state_machine import ExchangeState
+
+
+class InvalidCandidate(ValueError):
+    """Raised when a candidate lacks a recognized evidence-driven kind."""
+
+
+def plan_candidate(
+    conn: sqlite3.Connection,
+    dossier: dict,
+    *,
+    kind: str,
+    rationale: str,
+    tractability: float = 0.5,
+    testability: float = 0.5,
+    exchange_id: str | None = None,
+    persist: bool = True,
+) -> ContributionCandidate:
+    """Build (and optionally persist) an evidence-driven contribution candidate."""
+    if kind not in CONTRIBUTION_KINDS:
+        raise InvalidCandidate(
+            f"kind '{kind}' is not evidence-driven; expected one of {CONTRIBUTION_KINDS}",
+        )
+    ex_id = exchange_id or dossier.get("_exchange_id", "")
+    score = contribution_score(
+        dossier,
+        has_verified_friction=True,  # a candidate exists => friction is verified
+        tractability=tractability,
+        testability=testability,
+        existing_evidence=True,
+    )
+    candidate = ContributionCandidate(
+        exchange_id=ex_id,
+        external_repo=dossier.get("external_repo", ""),
+        kind=kind,
+        rationale=rationale,
+        contribution_score=score,
+        status="candidate",
+    )
+    if persist:
+        store.init_exchange_schema(conn)
+        store.insert_contribution_candidate(conn, candidate)
+        if ex_id:
+            store.advance_exchange(
+                conn, ex_id, ExchangeState.CONTRIBUTION_CANDIDATE.value,
+                data={"contribution_kind": kind, "contribution_score": score},
+            )
+    return candidate

--- a/src/organvm_engine/contrib/policy.py
+++ b/src/organvm_engine/contrib/policy.py
@@ -1,0 +1,106 @@
+"""Autonomy + safety policy for BIFRONS outbound contributions.
+
+The portal's outbound authority is bounded by an autonomy level. The default is
+A2 — *prepare, never submit*: local branches, patches, tests, and contribution
+packets are produced, but nothing is opened upstream without explicit human
+authorization. A4 (allowlisted autonomy) is reserved for narrowly-defined
+low-risk classes to explicitly allowlisted repos.
+
+This is an operational quality constraint, not a moral one: indiscriminate
+contributions would damage signal quality and relationship capital.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+
+
+class AutonomyLevel(IntEnum):
+    OBSERVE = 0     # A0 — index and monitor only
+    INTERPRET = 1   # A1 — dossiers, mappings, suggestions
+    PREPARE = 2     # A2 — local branches, patches, tests, packets (DEFAULT)
+    SUBMIT_WITH_APPROVAL = 3  # A3 — open issue/PR only after explicit approval
+    ALLOWLISTED = 4  # A4 — auto-submit predefined low-risk classes to allowlisted repos
+
+
+DEFAULT_AUTONOMY = AutonomyLevel.PREPARE
+
+# Contribution kinds A4 may ever auto-submit (narrow, deterministic, low-risk).
+LOW_RISK_KINDS = frozenset({
+    "documentation-ambiguity",       # typo / broken-doc-link corrections
+    "missing-test-or-fixture",       # deterministic fixture/test additions
+})
+
+
+@dataclass
+class ContributionPolicy:
+    autonomy: AutonomyLevel = DEFAULT_AUTONOMY
+    allowlist: set[str] = field(default_factory=set)  # owner/repo entries for A4
+    open_pr_cap: int = 3          # max concurrent open PRs per repo
+    submission_rate_cap: int = 5  # max submissions per run
+
+
+@dataclass
+class SubmitDecision:
+    allowed: bool
+    reason: str
+    requires_human: bool = False
+
+
+def is_allowlisted(policy: ContributionPolicy, repo: str) -> bool:
+    return repo in policy.allowlist
+
+
+def is_low_risk(kind: str) -> bool:
+    return kind in LOW_RISK_KINDS
+
+
+def authorize_submit(
+    policy: ContributionPolicy,
+    *,
+    external_repo: str,
+    kind: str,
+    human_approved: bool = False,
+    checks_passing: bool = False,
+    duplicate_exists: bool = False,
+    open_prs: int = 0,
+    maintainer_opt_out: bool = False,
+) -> SubmitDecision:
+    """Decide whether an upstream submission is authorized.
+
+    The external-write boundary. Everything before this is preparation.
+    """
+    if duplicate_exists:
+        return SubmitDecision(False, "duplicate issue/PR already exists")
+    if maintainer_opt_out:
+        return SubmitDecision(False, "maintainer prohibits automated contributions")
+    if open_prs >= policy.open_pr_cap:
+        return SubmitDecision(False, f"open-PR cap reached ({policy.open_pr_cap})")
+
+    # A4: allowlisted autonomy for low-risk classes only.
+    if policy.autonomy >= AutonomyLevel.ALLOWLISTED:
+        if not is_allowlisted(policy, external_repo):
+            return SubmitDecision(False, f"{external_repo} is not allowlisted", requires_human=True)
+        if not is_low_risk(kind):
+            return SubmitDecision(
+                False, f"kind '{kind}' is not a low-risk class", requires_human=True,
+            )
+        if not checks_passing:
+            return SubmitDecision(False, "upstream checks not passing")
+        return SubmitDecision(True, "A4 allowlisted low-risk auto-submit")
+
+    # A3: submit only with explicit human approval.
+    if policy.autonomy == AutonomyLevel.SUBMIT_WITH_APPROVAL:
+        if human_approved and checks_passing:
+            return SubmitDecision(True, "A3 human-approved submission")
+        return SubmitDecision(
+            False, "A3 requires explicit human approval + passing checks",
+            requires_human=True,
+        )
+
+    # A2 and below: prepare only, never submit.
+    return SubmitDecision(
+        False, f"autonomy {policy.autonomy.name} (A{int(policy.autonomy)}) prepares, never submits",
+        requires_human=True,
+    )

--- a/src/organvm_engine/contrib/validator.py
+++ b/src/organvm_engine/contrib/validator.py
@@ -1,0 +1,64 @@
+"""Contribution validation for BIFRONS.
+
+Plans (and, when explicitly executed, runs) the upstream project's own
+formatting/linting/tests plus a reproduction of the problem, in the disposable
+workspace. Defaults to a plan only: nothing is executed and no upstream code is
+run during preparation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from organvm_engine.contrib.worktree import WorkspacePlan
+
+# Common upstream check commands, probed by manifest presence.
+_CHECK_COMMANDS = {
+    "pyproject.toml": ["ruff check .", "pytest -q"],
+    "package.json": ["npm test"],
+    "go.mod": ["go test ./..."],
+    "Cargo.toml": ["cargo test"],
+}
+
+
+@dataclass
+class ValidationResult:
+    external_repo: str
+    ref: str
+    reproduction: str = ""
+    commands: list[str] = field(default_factory=list)
+    executed: bool = False
+    passing: bool | None = None
+
+    def as_dict(self) -> dict:
+        return {
+            "external_repo": self.external_repo,
+            "ref": self.ref,
+            "reproduction": self.reproduction,
+            "commands": self.commands,
+            "executed": self.executed,
+            "passing": self.passing,
+        }
+
+
+def plan_validation(
+    workspace: WorkspacePlan,
+    *,
+    manifests: list[str] | None = None,
+    reproduction: str = "",
+    execute: bool = False,
+) -> ValidationResult:
+    """Plan the upstream check + reproduction. ``execute=False`` runs nothing."""
+    commands: list[str] = []
+    for manifest in manifests or []:
+        commands.extend(_CHECK_COMMANDS.get(manifest, []))
+    if not commands:
+        commands = ["# no recognized upstream check commands detected"]
+    return ValidationResult(
+        external_repo=workspace.external_repo,
+        ref=workspace.ref,
+        reproduction=reproduction,
+        commands=commands,
+        executed=bool(execute),
+        passing=None,  # unknown until an authorized execution runs them
+    )

--- a/src/organvm_engine/contrib/worktree.py
+++ b/src/organvm_engine/contrib/worktree.py
@@ -1,0 +1,79 @@
+"""Ephemeral contribution workspaces for BIFRONS (S3 materialization).
+
+Plans (and, only when explicitly executed, creates) a disposable fork/worktree
+pinned to an exact upstream ref. Defaults to a dry-run plan: no fork, no clone,
+no code execution. Security invariants enforced here:
+
+* every workspace is pinned to an exact commit;
+* builds/tests run in a disposable sandbox (never the live checkout);
+* upstream GitHub Actions are never run with ORGANVM secrets;
+* fetched code is never executed during planning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class WorkspacePlan:
+    external_repo: str
+    ref: str
+    fork: str
+    worktree_path: str
+    executed: bool = False
+    steps: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "external_repo": self.external_repo,
+            "ref": self.ref,
+            "fork": self.fork,
+            "worktree_path": self.worktree_path,
+            "executed": self.executed,
+            "steps": self.steps,
+        }
+
+
+def _sandbox_root() -> Path:
+    return Path("~/.organvm/bifrons/workspaces").expanduser()
+
+
+def plan_workspace(
+    external_repo: str,
+    ref: str,
+    *,
+    fork_owner: str = "4444J99",
+    base_dir: Path | None = None,
+    execute: bool = False,
+) -> WorkspacePlan:
+    """Plan an ephemeral, pinned contribution workspace.
+
+    With ``execute=False`` (default) this returns the plan without touching git
+    or the network — the safe default. ``execute=True`` is reserved for an
+    explicitly-authorized run and is intentionally left to the caller to wire to
+    real git operations behind the human gate.
+    """
+    if not ref:
+        raise ValueError("a workspace must be pinned to an exact ref")
+    owner_repo = external_repo.split("/")
+    name = owner_repo[-1] if owner_repo else external_repo
+    root = base_dir or _sandbox_root()
+    worktree_path = str(root / f"{name}@{ref[:10]}")
+    fork = f"{fork_owner}/{name}"
+
+    steps = [
+        f"gh repo fork {external_repo} --clone=false  # -> {fork}",
+        f"git clone --depth 1 --branch {ref} https://github.com/{fork} {worktree_path}",
+        f"git -C {worktree_path} checkout {ref}",
+        "# disposable sandbox; upstream Actions NOT run with ORGANVM secrets",
+    ]
+    return WorkspacePlan(
+        external_repo=external_repo,
+        ref=ref,
+        fork=fork,
+        worktree_path=worktree_path,
+        executed=bool(execute),
+        steps=steps,
+    )

--- a/src/organvm_engine/network/convergence.py
+++ b/src/organvm_engine/network/convergence.py
@@ -1,0 +1,76 @@
+"""Cross-organ convergence detection for BIFRONS.
+
+A starred repository often resonates with several ORGANVM repositories through
+different lenses — a convergence point. Surfacing these prevents forcing a star
+into one organ and reveals where external material touches the system broadly.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Convergence:
+    external_repo: str
+    internal_repos: list[str] = field(default_factory=list)
+    lenses: list[str] = field(default_factory=list)
+    max_score: float = 0.0
+
+    def as_dict(self) -> dict:
+        return {
+            "external_repo": self.external_repo,
+            "internal_repos": self.internal_repos,
+            "lenses": self.lenses,
+            "max_score": self.max_score,
+            "breadth": len(self.internal_repos),
+        }
+
+
+def find_convergences(
+    conn: sqlite3.Connection,
+    *,
+    min_repos: int = 2,
+) -> list[Convergence]:
+    """External repos resonating with >= ``min_repos`` distinct internal repos."""
+    try:
+        rows = conn.execute(
+            "SELECT external_repo, internal_repo, lens, score FROM resonance_edge",
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+
+    grouped: dict[str, Convergence] = {}
+    repos_seen: dict[str, set] = {}
+    lenses_seen: dict[str, set] = {}
+    for row in rows:
+        ext = row["external_repo"]
+        conv = grouped.setdefault(ext, Convergence(external_repo=ext))
+        repos_seen.setdefault(ext, set()).add(row["internal_repo"])
+        lenses_seen.setdefault(ext, set()).add(row["lens"])
+        conv.max_score = max(conv.max_score, row["score"])
+
+    result: list[Convergence] = []
+    for ext, conv in grouped.items():
+        repos = sorted(repos_seen[ext])
+        if len(repos) >= min_repos:
+            conv.internal_repos = repos
+            conv.lenses = sorted(lenses_seen[ext])
+            result.append(conv)
+    result.sort(key=lambda c: (len(c.internal_repos), c.max_score), reverse=True)
+    return result
+
+
+def convergence_report(conn: sqlite3.Connection, *, min_repos: int = 2) -> str:
+    """Human-readable convergence summary."""
+    convs = find_convergences(conn, min_repos=min_repos)
+    if not convs:
+        return "No cross-organ convergences found."
+    lines = [f"{len(convs)} convergence point(s):"]
+    for c in convs:
+        lines.append(
+            f"  {c.external_repo} -> {len(c.internal_repos)} repos "
+            f"[{', '.join(c.lenses)}] (max {c.max_score})",
+        )
+    return "\n".join(lines)

--- a/src/organvm_engine/network/discover.py
+++ b/src/organvm_engine/network/discover.py
@@ -827,7 +827,7 @@ def suggest_parallel_mirrors(
                         project=proj["project"],
                         platform="github",
                         relevance=proj["relevance"],
-                        engagement=["watch", "discussions"],
+                        engagement=["presence", "dialogue"],
                         tags=["suggested", "parallel", domain],
                     ))
 
@@ -843,7 +843,7 @@ def suggest_parallel_mirrors(
                             project=proj["project"],
                             platform="github",
                             relevance=proj["relevance"],
-                            engagement=["watch", "discussions"],
+                            engagement=["presence", "dialogue"],
                             tags=["suggested", "parallel", domain],
                         ))
 

--- a/src/organvm_engine/network/resonance.py
+++ b/src/organvm_engine/network/resonance.py
@@ -1,0 +1,206 @@
+"""Resonance scoring for BIFRONS — map absorbed repos to ORGANVM repos.
+
+Two independent scores, never collapsed into one number:
+
+* absorption score  — how valuable the repo is as *material* for ORGANVM
+* contribution score — whether ORGANVM can return legitimate value upstream
+
+And three resonance lenses (mirroring the network mirror lenses): technical
+dependency, domain parallel, philosophical kinship. Weights are initial
+configurable heuristics whose values should evolve from actual outcomes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Absorption score component weights (sum = 1.0 before penalties).
+ABSORPTION_WEIGHTS = {
+    "resonance": 0.25,
+    "applicability": 0.20,
+    "novelty": 0.15,
+    "upstream_health": 0.15,
+    "convergence": 0.10,
+    "temporal": 0.10,
+    "aesthetic": 0.05,
+}
+
+# Contribution score component weights (sum = 1.0 before penalties).
+CONTRIBUTION_WEIGHTS = {
+    "verified_friction": 0.25,
+    "tractability": 0.20,
+    "testability": 0.20,
+    "receptivity": 0.15,
+    "existing_evidence": 0.10,
+    "strategic": 0.10,
+}
+
+# Minimum lens score for a resonance edge to be recorded.
+DEFAULT_EDGE_THRESHOLD = 0.15
+
+_STOPWORDS = frozenset({
+    "the", "a", "an", "and", "or", "for", "to", "of", "in", "on", "with", "is",
+    "fast", "simple", "tool", "library", "framework", "python", "rust", "js",
+})
+
+
+@dataclass
+class InternalRepo:
+    """A lightweight descriptor of an ORGANVM repo to map stars against."""
+
+    name: str
+    organ: str = ""
+    languages: set[str] = field(default_factory=set)
+    topics: set[str] = field(default_factory=set)
+    description: str = ""
+
+
+@dataclass
+class ResonanceEdge:
+    internal_repo: str
+    lens: str
+    score: float
+    evidence: list[str] = field(default_factory=list)
+
+
+def _words(text: str) -> set[str]:
+    return {
+        w for w in "".join(c.lower() if c.isalnum() else " " for c in text).split()
+        if len(w) > 2 and w not in _STOPWORDS
+    }
+
+
+def _jaccard(a: set, b: set) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _dossier_languages(dossier: dict) -> set[str]:
+    langs = set((dossier.get("identity", {}).get("languages") or {}).keys())
+    primary = dossier.get("identity", {}).get("primary_language")
+    if primary:
+        langs.add(primary)
+    return {lang_.lower() for lang_ in langs}
+
+
+def compute_resonance(
+    dossier: dict,
+    internal_repos: list[InternalRepo],
+    *,
+    threshold: float = DEFAULT_EDGE_THRESHOLD,
+) -> list[ResonanceEdge]:
+    """Score a dossier against each internal repo across the three lenses."""
+    ext_langs = _dossier_languages(dossier)
+    ext_topics = {t.lower() for t in dossier.get("identity", {}).get("topics", [])}
+    ext_words = _words(dossier.get("identity", {}).get("description", ""))
+
+    edges: list[ResonanceEdge] = []
+    for repo in internal_repos:
+        # technical: shared languages
+        lang_overlap = ext_langs & {lang_.lower() for lang_ in repo.languages}
+        tech = _jaccard(ext_langs, {lang_.lower() for lang_ in repo.languages})
+        if tech >= threshold:
+            edges.append(ResonanceEdge(
+                repo.name, "technical", round(tech, 3),
+                [f"shared language: {', '.join(sorted(lang_overlap))}"] if lang_overlap else [],
+            ))
+        # parallel: shared topics
+        topic_overlap = ext_topics & {t.lower() for t in repo.topics}
+        par = _jaccard(ext_topics, {t.lower() for t in repo.topics})
+        if par >= threshold:
+            edges.append(ResonanceEdge(
+                repo.name, "parallel", round(par, 3),
+                [f"shared topics: {', '.join(sorted(topic_overlap))}"] if topic_overlap else [],
+            ))
+        # kinship: description word overlap
+        kin = _jaccard(ext_words, _words(repo.description))
+        if kin >= threshold:
+            shared = ext_words & _words(repo.description)
+            edges.append(ResonanceEdge(
+                repo.name, "kinship", round(kin, 3),
+                [f"shared concepts: {', '.join(sorted(shared))}"] if shared else [],
+            ))
+    return edges
+
+
+def _upstream_health(dossier: dict) -> float:
+    state = dossier.get("state", {})
+    score = 1.0
+    if state.get("archived"):
+        score -= 0.6
+    if state.get("fork"):
+        score -= 0.2
+    if not state.get("last_push_at"):
+        score -= 0.2
+    return max(0.0, min(1.0, score))
+
+
+def absorption_score(dossier: dict, edges: list[ResonanceEdge]) -> float:
+    """Weighted absorption score in [0, 1] (higher = more valuable material)."""
+    resonance = max((e.score for e in edges), default=0.0)
+    distinct_internal = {e.internal_repo for e in edges}
+    applicability = min(1.0, len(distinct_internal) / 3.0)
+    convergence = min(1.0, len(distinct_internal) / 5.0)
+    topics = dossier.get("identity", {}).get("topics", [])
+    novelty = min(1.0, 0.3 + 0.1 * len(topics))
+    upstream = _upstream_health(dossier)
+    temporal = 1.0 if dossier.get("state", {}).get("last_push_at") else 0.4
+    aesthetic = 1.0 if dossier.get("identity", {}).get("description") else 0.2
+
+    components = {
+        "resonance": resonance,
+        "applicability": applicability,
+        "novelty": novelty,
+        "upstream_health": upstream,
+        "convergence": convergence,
+        "temporal": temporal,
+        "aesthetic": aesthetic,
+    }
+    base = sum(ABSORPTION_WEIGHTS[k] * v for k, v in components.items())
+
+    # penalties
+    contracts = dossier.get("contracts", {})
+    license_class = contracts.get("license", {}).get("class", "unknown")
+    penalty = 0.0
+    if license_class in ("none", "unknown"):
+        penalty += 0.05
+    if dossier.get("state", {}).get("archived"):
+        penalty += 0.15
+    return round(max(0.0, min(1.0, base - penalty)), 3)
+
+
+def contribution_score(
+    dossier: dict,
+    *,
+    has_verified_friction: bool = False,
+    tractability: float = 0.5,
+    testability: float = 0.5,
+    existing_evidence: bool = False,
+) -> float:
+    """Weighted contribution score in [0, 1] (can we return value upstream)."""
+    contracts = dossier.get("contracts", {})
+    # receptivity: has CONTRIBUTING + not requiring a CLA is more receptive.
+    receptivity = 0.4
+    if contracts.get("contributing"):
+        receptivity += 0.3
+    if contracts.get("cla_or_dco") in ("dco", "none"):
+        receptivity += 0.2
+    strategic = min(1.0, 0.4 + 0.1 * len(dossier.get("identity", {}).get("topics", [])))
+
+    components = {
+        "verified_friction": 1.0 if has_verified_friction else 0.0,
+        "tractability": max(0.0, min(1.0, tractability)),
+        "testability": max(0.0, min(1.0, testability)),
+        "receptivity": min(1.0, receptivity),
+        "existing_evidence": 1.0 if existing_evidence else 0.0,
+        "strategic": strategic,
+    }
+    base = sum(CONTRIBUTION_WEIGHTS[k] * v for k, v in components.items())
+
+    penalty = 0.0
+    if dossier.get("state", {}).get("archived"):
+        penalty += 0.3
+    if contracts.get("cla_or_dco") == "cla":
+        penalty += 0.1
+    return round(max(0.0, min(1.0, base - penalty)), 3)

--- a/src/organvm_engine/network/scanner.py
+++ b/src/organvm_engine/network/scanner.py
@@ -106,7 +106,7 @@ def scan_pyproject(repo_path: Path) -> list[MirrorEntry]:
                 project=github_repo,
                 platform="github",
                 relevance=f"Python dependency: {raw_name}",
-                engagement=["watch"],
+                engagement=["presence"],
                 tags=["auto-discovered", "python-dep"],
             ))
 
@@ -143,7 +143,7 @@ def scan_package_json(repo_path: Path) -> list[MirrorEntry]:
                     project=github_repo,
                     platform="github",
                     relevance=f"JS/TS dependency: {pkg_name}",
-                    engagement=["watch"],
+                    engagement=["presence"],
                     tags=["auto-discovered", "js-dep"],
                 ))
 
@@ -183,7 +183,7 @@ def scan_go_mod(repo_path: Path) -> list[MirrorEntry]:
                                 project=github_repo,
                                 platform="github",
                                 relevance=f"Go dependency: {mod_path}",
-                                engagement=["watch"],
+                                engagement=["presence"],
                                 tags=["auto-discovered", "go-dep"],
                             ))
             continue
@@ -201,7 +201,7 @@ def scan_go_mod(repo_path: Path) -> list[MirrorEntry]:
                                 project=github_repo,
                                 platform="github",
                                 relevance=f"Go dependency: {mod_path}",
-                                engagement=["watch"],
+                                engagement=["presence"],
                                 tags=["auto-discovered", "go-dep"],
                             ))
 
@@ -238,7 +238,7 @@ def scan_cargo_toml(repo_path: Path) -> list[MirrorEntry]:
                         project=github_repo,
                         platform="github",
                         relevance=f"Rust dependency: {crate_name}",
-                        engagement=["watch"],
+                        engagement=["presence"],
                         tags=["auto-discovered", "rust-dep"],
                     ))
 

--- a/src/organvm_engine/network/star_importer.py
+++ b/src/organvm_engine/network/star_importer.py
@@ -1,0 +1,128 @@
+"""Compile the BIFRONS star corpus into ORGANVM network relationships.
+
+Reads dossiers (written by alchemia) from the shared portal store, scores each
+against the internal repos across the three lenses, records resonance edges, and
+advances each exchange to MAPPED. This is the bridge from *absorption* (alchemia)
+to *relationship* (the network mirror machinery).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+
+from organvm_engine.network.resonance import (
+    InternalRepo,
+    ResonanceEdge,
+    absorption_score,
+    compute_resonance,
+    contribution_score,
+)
+from organvm_engine.network.schema import MirrorEntry
+from organvm_engine.portal import store
+from organvm_engine.portal.state_machine import ExchangeState
+
+
+@dataclass
+class ImportSummary:
+    dossiers: int = 0
+    edges: int = 0
+    mapped: int = 0
+    unresolved: int = 0
+    unresolved_repos: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "dossiers": self.dossiers,
+            "edges": self.edges,
+            "mapped": self.mapped,
+            "unresolved": self.unresolved,
+        }
+
+
+def import_stars(
+    conn: sqlite3.Connection,
+    internal_repos: list[InternalRepo],
+    *,
+    level: str = "S1",
+) -> ImportSummary:
+    """Import all dossiers of ``level`` into resonance edges. Idempotent."""
+    store.init_exchange_schema(conn)
+    dossiers = store.list_dossiers(conn, level=level)
+    summary = ImportSummary(dossiers=len(dossiers))
+
+    for dossier in dossiers:
+        exchange_id = dossier.get("_exchange_id", "")
+        full_name = dossier.get("external_repo", "")
+        node_id = dossier.get("github_node_id", "")
+        edges = compute_resonance(dossier, internal_repos)
+
+        if not edges:
+            summary.unresolved += 1
+            summary.unresolved_repos.append(full_name)
+            continue
+
+        for edge in edges:
+            store.upsert_resonance_edge(
+                conn,
+                exchange_id=exchange_id,
+                external_node_id=node_id,
+                external_repo=full_name,
+                internal_repo=edge.internal_repo,
+                lens=edge.lens,
+                score=edge.score,
+                evidence=edge.evidence,
+            )
+            summary.edges += 1
+
+        # Persist the two independent scores on the exchange and advance to MAPPED.
+        if exchange_id:
+            store.advance_exchange(
+                conn, exchange_id, ExchangeState.MAPPED.value,
+                data={
+                    "absorption_score": absorption_score(dossier, edges),
+                    "contribution_score": contribution_score(dossier),
+                    "resonance_edges": len(edges),
+                },
+            )
+        summary.mapped += 1
+
+    conn.commit()
+    return summary
+
+
+def mirror_entries_for_internal(
+    conn: sqlite3.Connection,
+    internal_repo: str,
+) -> dict[str, list[MirrorEntry]]:
+    """Project recorded resonance edges into per-lens MirrorEntry lists.
+
+    Feeds the existing network-map machinery (network-map.yaml) — the star
+    importer feeds that machinery rather than duplicating it.
+    """
+    rows = conn.execute(
+        "SELECT external_repo, lens, score, evidence_json FROM resonance_edge "
+        "WHERE internal_repo=? ORDER BY score DESC",
+        (internal_repo,),
+    ).fetchall()
+    out: dict[str, list[MirrorEntry]] = {"technical": [], "parallel": [], "kinship": []}
+    import json
+    for row in rows:
+        lens = row["lens"]
+        if lens not in out:
+            continue
+        evidence = json.loads(row["evidence_json"] or "[]")
+        out[lens].append(MirrorEntry(
+            project=row["external_repo"],
+            platform="github",
+            relevance="; ".join(evidence) or f"{lens} resonance {row['score']}",
+            engagement=["presence"],
+            url=f"https://github.com/{row['external_repo']}",
+            tags=["bifrons-star", f"score:{row['score']}"],
+        ))
+    return out
+
+
+def resonance_edges_as_relations(edges: list[ResonanceEdge]) -> list[str]:
+    """Small helper: the lens relations implied by a set of edges."""
+    return sorted({e.lens for e in edges})

--- a/src/organvm_engine/portal/__init__.py
+++ b/src/organvm_engine/portal/__init__.py
@@ -1,0 +1,27 @@
+"""BIFRONS portal — the compile/decide half of the star<->contribution portal.
+
+BIFRONS (Janus, two-faced) absorbs starred repositories (via alchemia) and
+returns value both inward (transmutation proposals that evolve ORGANVM repos)
+and outward (upstream contributions), metabolizing the response back through the
+seven organs. This package owns, inside organvm-engine:
+
+* store       — the engine's half of the shared portal.db (exchange tables)
+* models      — TransmutationProposal, ContributionCandidate
+* proposals   — generate inbound transmutation proposals from dossiers+resonance
+* state_machine — the exchange lifecycle FSM
+
+Naming: distinct from IANVA (the MCP doorway/aggregator).
+"""
+
+from organvm_engine.portal.models import (
+    ContributionCandidate,
+    TransmutationProposal,
+)
+from organvm_engine.portal.state_machine import ExchangeState, PortalStateMachine
+
+__all__ = [
+    "ContributionCandidate",
+    "ExchangeState",
+    "PortalStateMachine",
+    "TransmutationProposal",
+]

--- a/src/organvm_engine/portal/models.py
+++ b/src/organvm_engine/portal/models.py
@@ -1,0 +1,78 @@
+"""Portal domain models — transmutation proposals and contribution candidates."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# Transmutation proposal classes (what can be learned from an absorbed repo).
+PROPOSAL_CLASSES = (
+    "architecture-pattern",
+    "interface-adoption",
+    "testing-technique",
+    "documentation-structure",
+    "dev-tool-integration",
+    "performance-strategy",
+    "interoperability-adapter",
+    "visual-reference",
+    "research-note",
+    "dependency-adoption",
+    "deprecation-or-security-warning",
+)
+
+# Contribution candidate kinds (evidence-driven; a candidate needs one of these).
+CONTRIBUTION_KINDS = (
+    "reproducible-defect",
+    "documentation-ambiguity",
+    "missing-test-or-fixture",
+    "compatibility-problem",
+    "performance-or-reliability",
+    "interoperability-adapter",
+    "scoped-feature",
+)
+
+
+@dataclass
+class TransmutationProposal:
+    """An inbound proposal: what an absorbed repo could teach an ORGANVM repo.
+
+    Never a silent code transplant — a described, license-gated change with tests
+    and a rollback, realized as a *draft* internal PR only after approval.
+    """
+
+    exchange_id: str
+    external_repo: str
+    source_ref: str
+    target_repo: str
+    klass: str
+    finding: str = ""
+    proposed_change: str = ""
+    license_decision: str = ""
+    abstraction_level: str = "idea"  # idea | interface | code
+    files_changed: list[str] = field(default_factory=list)
+    tests_required: list[str] = field(default_factory=list)
+    copied_code: bool = False
+    status: str = "proposed"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ContributionCandidate:
+    """An outbound candidate: a legitimate improvement to return upstream.
+
+    Generated only when ORGANVM holds real evidence (a defect, a confirmed doc
+    ambiguity, a missing test, ...). Default posture is prepare, never submit.
+    """
+
+    exchange_id: str
+    external_repo: str
+    kind: str
+    rationale: str = ""
+    contribution_score: float = 0.0
+    status: str = "candidate"
+    packet: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/src/organvm_engine/portal/proposals.py
+++ b/src/organvm_engine/portal/proposals.py
@@ -1,0 +1,72 @@
+"""Generate inbound transmutation proposals from dossiers.
+
+The inbound side never silently transplants source code. It produces a
+*transmutation proposal*: what can be learned from an absorbed repo and how it
+could alter a specific ORGANVM repo — gated by the license firewall, and
+realized (later, on approval) as a draft internal PR, never a default-branch write.
+"""
+
+from __future__ import annotations
+
+from organvm_engine.portal.models import TransmutationProposal
+
+# License decision -> permitted abstraction level + whether code may be copied.
+_ABSTRACTION_BY_DECISION = {
+    "code-adaptation-with-attribution": ("code", True),
+    "idea-or-interface-only-unless-obligations-accepted": ("interface", False),
+    "no-code-or-asset-copying": ("idea", False),
+}
+
+
+def _infer_class(dossier: dict) -> str:
+    arch = dossier.get("architecture", {})
+    manifests = arch.get("manifests", [])
+    test_strategy = arch.get("test_strategy", [])
+    if "Dockerfile" in manifests:
+        return "dev-tool-integration"
+    if test_strategy:
+        return "testing-technique"
+    if ".github/workflows" in manifests:
+        return "dev-tool-integration"
+    return "architecture-pattern"
+
+
+def propose_transmutation(
+    dossier: dict,
+    target_repo: str,
+    *,
+    klass: str | None = None,
+    exchange_id: str | None = None,
+) -> TransmutationProposal:
+    """Build a license-gated transmutation proposal for ``target_repo``."""
+    contracts = dossier.get("contracts", {})
+    decision = contracts.get("decision", "no-code-or-asset-copying")
+    abstraction, may_copy = _ABSTRACTION_BY_DECISION.get(decision, ("idea", False))
+    resolved_class = klass or _infer_class(dossier)
+    ext_repo = dossier.get("external_repo", "")
+    source_ref = dossier.get("snapshot_ref", "")
+
+    finding = (
+        f"{ext_repo} demonstrates a {resolved_class.replace('-', ' ')} relevant to "
+        f"{target_repo}."
+    )
+    proposed = (
+        f"Adopt the {resolved_class.replace('-', ' ')} at the '{abstraction}' level "
+        f"in {target_repo}, with attribution and provenance to {ext_repo}@{source_ref[:10]}."
+    )
+
+    return TransmutationProposal(
+        exchange_id=exchange_id or dossier.get("_exchange_id", ""),
+        external_repo=ext_repo,
+        source_ref=source_ref,
+        target_repo=target_repo,
+        klass=resolved_class,
+        finding=finding,
+        proposed_change=proposed,
+        license_decision=decision,
+        abstraction_level=abstraction,
+        files_changed=[],
+        tests_required=[f"tests covering the adopted {resolved_class}"],
+        copied_code=may_copy and abstraction == "code",
+        status="proposed",
+    )

--- a/src/organvm_engine/portal/state_machine.py
+++ b/src/organvm_engine/portal/state_machine.py
@@ -1,0 +1,107 @@
+"""Exchange lifecycle state machine for the BIFRONS portal.
+
+One star's traversal moves through a shared prefix (STARRED -> MAPPED) and then
+forks into an inbound branch (internal evolution) and/or an outbound branch
+(upstream contribution), both converging on BACKFLOW_COMPLETE.
+
+Every transition is idempotent, timestamped (by the store), evidence-backed,
+reversible where technically possible, and attributable.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ExchangeState(str, Enum):
+    # shared prefix
+    STARRED = "STARRED"
+    INDEXED = "INDEXED"
+    DOSSIERED = "DOSSIERED"
+    MAPPED = "MAPPED"
+    # inbound (internal evolution)
+    ABSORPTION_CANDIDATE = "ABSORPTION_CANDIDATE"
+    INTERNAL_PROPOSAL = "INTERNAL_PROPOSAL"
+    INTERNAL_PREPARED = "INTERNAL_PREPARED"
+    INTERNAL_PR_OPEN = "INTERNAL_PR_OPEN"
+    INTERNAL_MERGED = "INTERNAL_MERGED"
+    # outbound (upstream contribution)
+    CONTRIBUTION_CANDIDATE = "CONTRIBUTION_CANDIDATE"
+    UPSTREAM_POLICY_CHECKED = "UPSTREAM_POLICY_CHECKED"
+    REPRODUCED = "REPRODUCED"
+    PATCH_PREPARED = "PATCH_PREPARED"
+    HUMAN_APPROVED = "HUMAN_APPROVED"
+    UPSTREAM_SUBMITTED = "UPSTREAM_SUBMITTED"
+    MERGED = "MERGED"
+    DECLINED = "DECLINED"
+    DORMANT = "DORMANT"
+    # convergence
+    BACKFLOW_COMPLETE = "BACKFLOW_COMPLETE"
+
+
+# Allowed transitions (directed). A state maps to the set it may advance to.
+_TRANSITIONS: dict[ExchangeState, set[ExchangeState]] = {
+    ExchangeState.STARRED: {ExchangeState.INDEXED},
+    ExchangeState.INDEXED: {ExchangeState.DOSSIERED},
+    ExchangeState.DOSSIERED: {ExchangeState.MAPPED},
+    ExchangeState.MAPPED: {
+        ExchangeState.ABSORPTION_CANDIDATE,
+        ExchangeState.CONTRIBUTION_CANDIDATE,
+    },
+    # inbound branch
+    ExchangeState.ABSORPTION_CANDIDATE: {ExchangeState.INTERNAL_PROPOSAL},
+    ExchangeState.INTERNAL_PROPOSAL: {ExchangeState.INTERNAL_PREPARED},
+    ExchangeState.INTERNAL_PREPARED: {ExchangeState.INTERNAL_PR_OPEN},
+    ExchangeState.INTERNAL_PR_OPEN: {
+        ExchangeState.INTERNAL_MERGED,
+        ExchangeState.BACKFLOW_COMPLETE,
+    },
+    ExchangeState.INTERNAL_MERGED: {ExchangeState.BACKFLOW_COMPLETE},
+    # outbound branch
+    ExchangeState.CONTRIBUTION_CANDIDATE: {ExchangeState.UPSTREAM_POLICY_CHECKED},
+    ExchangeState.UPSTREAM_POLICY_CHECKED: {ExchangeState.REPRODUCED},
+    ExchangeState.REPRODUCED: {ExchangeState.PATCH_PREPARED},
+    ExchangeState.PATCH_PREPARED: {ExchangeState.HUMAN_APPROVED},
+    ExchangeState.HUMAN_APPROVED: {ExchangeState.UPSTREAM_SUBMITTED},
+    ExchangeState.UPSTREAM_SUBMITTED: {
+        ExchangeState.MERGED,
+        ExchangeState.DECLINED,
+        ExchangeState.DORMANT,
+    },
+    ExchangeState.MERGED: {ExchangeState.BACKFLOW_COMPLETE},
+    ExchangeState.DECLINED: {ExchangeState.BACKFLOW_COMPLETE},
+    ExchangeState.DORMANT: {ExchangeState.BACKFLOW_COMPLETE},
+    ExchangeState.BACKFLOW_COMPLETE: set(),
+}
+
+# The single external-write boundary: only past this line does anything leave
+# ORGANVM. Reaching it requires an explicit HUMAN_APPROVED predecessor.
+EXTERNAL_WRITE_STATE = ExchangeState.UPSTREAM_SUBMITTED
+
+
+class InvalidTransition(ValueError):
+    """Raised when an exchange is advanced along an illegal edge."""
+
+
+class PortalStateMachine:
+    """Validate and apply exchange lifecycle transitions."""
+
+    @staticmethod
+    def can_advance(current: ExchangeState, target: ExchangeState) -> bool:
+        return target in _TRANSITIONS.get(current, set())
+
+    @staticmethod
+    def advance(current: ExchangeState, target: ExchangeState) -> ExchangeState:
+        """Return ``target`` if the transition is legal, else raise."""
+        if target not in _TRANSITIONS.get(current, set()):
+            raise InvalidTransition(f"{current.value} -> {target.value} is not allowed")
+        return target
+
+    @staticmethod
+    def is_terminal(state: ExchangeState) -> bool:
+        return not _TRANSITIONS.get(state)
+
+    @staticmethod
+    def requires_human_approval(target: ExchangeState) -> bool:
+        """True for the transition that performs the external write."""
+        return target == EXTERNAL_WRITE_STATE

--- a/src/organvm_engine/portal/store.py
+++ b/src/organvm_engine/portal/store.py
@@ -246,7 +246,7 @@ def insert_transmutation_proposal(conn: sqlite3.Connection, proposal: Any) -> in
          json.dumps(proposal.tests_required), proposal.status, now_iso()),
     )
     conn.commit()
-    return int(cur.lastrowid)
+    return int(cur.lastrowid or 0)
 
 
 def insert_contribution_candidate(conn: sqlite3.Connection, candidate: Any) -> int:
@@ -261,7 +261,7 @@ def insert_contribution_candidate(conn: sqlite3.Connection, candidate: Any) -> i
          json.dumps(candidate.packet), now_iso()),
     )
     conn.commit()
-    return int(cur.lastrowid)
+    return int(cur.lastrowid or 0)
 
 
 def insert_backflow_signal(

--- a/src/organvm_engine/portal/store.py
+++ b/src/organvm_engine/portal/store.py
@@ -1,0 +1,294 @@
+"""Engine access to the shared BIFRONS portal store.
+
+The portal store (``~/.organvm/bifrons/portal.db``, override ``$BIFRONS_DB``) is
+written by alchemia (intake tables) and organvm-engine (exchange tables). This
+module owns the exchange-table DDL and provides readers over the intake tables
+(``external_repo``, ``dossier``, ``exchange``) that alchemia populated.
+
+The ``exchange`` DDL here MUST stay byte-identical to alchemia's copy — it is the
+spine both halves share. Keep it minimal.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# --- shared spine DDL (MUST match alchemia's storage.EXCHANGE_DDL verbatim) --
+EXCHANGE_DDL = """
+CREATE TABLE IF NOT EXISTS exchange (
+    exchange_id            TEXT PRIMARY KEY,
+    external_repo_node_id  TEXT NOT NULL,
+    external_repo          TEXT NOT NULL,
+    state                  TEXT NOT NULL,
+    created_at             TEXT NOT NULL,
+    updated_at             TEXT NOT NULL,
+    data_json              TEXT NOT NULL DEFAULT '{}'
+)
+"""
+
+# --- engine-owned exchange tables -------------------------------------------
+_EXCHANGE_DDL = [
+    """
+    CREATE TABLE IF NOT EXISTS resonance_edge (
+        id             INTEGER PRIMARY KEY AUTOINCREMENT,
+        exchange_id    TEXT NOT NULL,
+        external_node_id TEXT NOT NULL,
+        external_repo  TEXT NOT NULL,
+        internal_repo  TEXT NOT NULL,
+        lens           TEXT NOT NULL,
+        score          REAL NOT NULL,
+        confidence     REAL DEFAULT 1.0,
+        evidence_json  TEXT DEFAULT '[]',
+        created_at     TEXT NOT NULL,
+        UNIQUE(external_node_id, internal_repo, lens)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS transmutation_proposal (
+        id                INTEGER PRIMARY KEY AUTOINCREMENT,
+        exchange_id       TEXT NOT NULL,
+        external_repo     TEXT NOT NULL,
+        target_repo       TEXT NOT NULL,
+        klass             TEXT NOT NULL,
+        finding           TEXT DEFAULT '',
+        proposed_change   TEXT DEFAULT '',
+        license_decision  TEXT DEFAULT '',
+        files_json        TEXT DEFAULT '[]',
+        tests_json        TEXT DEFAULT '[]',
+        status            TEXT DEFAULT 'proposed',
+        created_at        TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS contribution_candidate (
+        id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+        exchange_id        TEXT NOT NULL,
+        external_repo      TEXT NOT NULL,
+        kind               TEXT NOT NULL,
+        rationale          TEXT DEFAULT '',
+        contribution_score REAL DEFAULT 0.0,
+        status             TEXT DEFAULT 'candidate',
+        packet_json        TEXT DEFAULT '{}',
+        created_at         TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS upstream_interaction (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        exchange_id     TEXT NOT NULL,
+        external_repo   TEXT NOT NULL,
+        kind            TEXT NOT NULL,
+        number          INTEGER,
+        url             TEXT DEFAULT '',
+        state           TEXT DEFAULT '',
+        review_decision TEXT DEFAULT '',
+        created_at      TEXT NOT NULL,
+        updated_at      TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS backflow_signal (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        exchange_id   TEXT NOT NULL,
+        external_repo TEXT NOT NULL,
+        signal_type   TEXT NOT NULL,
+        organ         TEXT NOT NULL,
+        content       TEXT DEFAULT '',
+        confidence    REAL DEFAULT 1.0,
+        created_at    TEXT NOT NULL
+    )
+    """,
+]
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def default_db_path() -> Path:
+    env = os.environ.get("BIFRONS_DB")
+    if env:
+        return Path(env).expanduser()
+    return Path("~/.organvm/bifrons/portal.db").expanduser()
+
+
+def connect(path: Path | str | None = None) -> sqlite3.Connection:
+    db_path = Path(path).expanduser() if path else default_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def init_exchange_schema(conn: sqlite3.Connection) -> None:
+    """Create the engine-owned exchange tables + the shared exchange spine."""
+    conn.execute(EXCHANGE_DDL)
+    for ddl in _EXCHANGE_DDL:
+        conn.execute(ddl)
+    conn.commit()
+
+
+# --- readers over alchemia's intake tables ----------------------------------
+def list_dossiers(conn: sqlite3.Connection, *, level: str = "S1") -> list[dict[str, Any]]:
+    """Return parsed dossier docs (alchemia-written) at the given level."""
+    try:
+        rows = conn.execute(
+            "SELECT node_id, full_name, doc_json, exchange_id FROM dossier WHERE level=?",
+            (level,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+    out = []
+    for row in rows:
+        doc = json.loads(row["doc_json"])
+        doc["_exchange_id"] = row["exchange_id"]
+        out.append(doc)
+    return out
+
+
+def get_dossier(conn: sqlite3.Connection, full_name: str, *, level: str = "S1") -> dict | None:
+    try:
+        row = conn.execute(
+            "SELECT node_id, full_name, doc_json, exchange_id FROM dossier "
+            "WHERE full_name=? AND level=?",
+            (full_name, level),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    if not row:
+        return None
+    doc = json.loads(row["doc_json"])
+    doc["_exchange_id"] = row["exchange_id"]
+    return doc
+
+
+def get_exchange(conn: sqlite3.Connection, exchange_id: str) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM exchange WHERE exchange_id=?", (exchange_id,),
+    ).fetchone()
+
+
+def exchange_for_repo(conn: sqlite3.Connection, full_name: str) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM exchange WHERE external_repo=? ORDER BY created_at DESC LIMIT 1",
+        (full_name,),
+    ).fetchone()
+
+
+def advance_exchange(
+    conn: sqlite3.Connection,
+    exchange_id: str,
+    state: str,
+    *,
+    data: dict | None = None,
+) -> None:
+    """Advance an exchange to a new state, merging optional data (engine writer)."""
+    row = get_exchange(conn, exchange_id)
+    merged: dict = {}
+    if row is not None:
+        try:
+            merged = json.loads(row["data_json"] or "{}")
+        except (ValueError, TypeError):
+            merged = {}
+    if data:
+        merged.update(data)
+    conn.execute(
+        "UPDATE exchange SET state=?, updated_at=?, data_json=? WHERE exchange_id=?",
+        (state, now_iso(), json.dumps(merged), exchange_id),
+    )
+    conn.commit()
+
+
+# --- writers for engine-owned tables ----------------------------------------
+def upsert_resonance_edge(
+    conn: sqlite3.Connection,
+    *,
+    exchange_id: str,
+    external_node_id: str,
+    external_repo: str,
+    internal_repo: str,
+    lens: str,
+    score: float,
+    confidence: float = 1.0,
+    evidence: list[str] | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO resonance_edge(exchange_id, external_node_id, external_repo,
+            internal_repo, lens, score, confidence, evidence_json, created_at)
+        VALUES(?,?,?,?,?,?,?,?,?)
+        ON CONFLICT(external_node_id, internal_repo, lens) DO UPDATE SET
+            score=excluded.score, confidence=excluded.confidence,
+            evidence_json=excluded.evidence_json
+        """,
+        (exchange_id, external_node_id, external_repo, internal_repo, lens, score,
+         confidence, json.dumps(evidence or []), now_iso()),
+    )
+
+
+def insert_transmutation_proposal(conn: sqlite3.Connection, proposal: Any) -> int:
+    cur = conn.execute(
+        """
+        INSERT INTO transmutation_proposal(exchange_id, external_repo, target_repo,
+            klass, finding, proposed_change, license_decision, files_json,
+            tests_json, status, created_at)
+        VALUES(?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        (proposal.exchange_id, proposal.external_repo, proposal.target_repo,
+         proposal.klass, proposal.finding, proposal.proposed_change,
+         proposal.license_decision, json.dumps(proposal.files_changed),
+         json.dumps(proposal.tests_required), proposal.status, now_iso()),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def insert_contribution_candidate(conn: sqlite3.Connection, candidate: Any) -> int:
+    cur = conn.execute(
+        """
+        INSERT INTO contribution_candidate(exchange_id, external_repo, kind,
+            rationale, contribution_score, status, packet_json, created_at)
+        VALUES(?,?,?,?,?,?,?,?)
+        """,
+        (candidate.exchange_id, candidate.external_repo, candidate.kind,
+         candidate.rationale, candidate.contribution_score, candidate.status,
+         json.dumps(candidate.packet), now_iso()),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def insert_backflow_signal(
+    conn: sqlite3.Connection,
+    *,
+    exchange_id: str,
+    external_repo: str,
+    signal_type: str,
+    organ: str,
+    content: str,
+    confidence: float = 1.0,
+) -> None:
+    conn.execute(
+        "INSERT INTO backflow_signal(exchange_id, external_repo, signal_type, "
+        "organ, content, confidence, created_at) VALUES(?,?,?,?,?,?,?)",
+        (exchange_id, external_repo, signal_type, organ, content, confidence, now_iso()),
+    )
+    conn.commit()
+
+
+def counts(conn: sqlite3.Connection) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for table in ("resonance_edge", "transmutation_proposal", "contribution_candidate",
+                  "upstream_interaction", "backflow_signal"):
+        try:
+            row = conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()  # noqa: S608
+            out[table] = int(row["n"])
+        except sqlite3.OperationalError:
+            out[table] = 0
+    return out

--- a/tests/test_contrib_planner.py
+++ b/tests/test_contrib_planner.py
@@ -1,0 +1,126 @@
+"""BIFRONS outbound pipeline — planner, policy gate, executor, backflow."""
+
+from __future__ import annotations
+
+import pytest
+
+from organvm_engine.contrib.backflow import metabolize_exchange
+from organvm_engine.contrib.executor import build_packet, prepare, submit
+from organvm_engine.contrib.planner import InvalidCandidate, plan_candidate
+from organvm_engine.contrib.policy import AutonomyLevel, ContributionPolicy, authorize_submit
+from organvm_engine.contrib.validator import plan_validation
+from organvm_engine.contrib.worktree import plan_workspace
+from organvm_engine.portal import store
+
+DOSSIER = {
+    "external_repo": "astral-sh/ruff",
+    "github_node_id": "R_1",
+    "snapshot_ref": "abc1234def",
+    "identity": {"description": "fast python linter", "topics": ["python", "linter"],
+                 "primary_language": "Rust", "languages": {"Rust": 1.0}},
+    "state": {"archived": False, "fork": False, "last_push_at": "2026-07-01T00:00:00Z"},
+    "contracts": {"license": {"spdx": "MIT", "class": "permissive"},
+                  "decision": "code-adaptation-with-attribution",
+                  "contributing": "CONTRIBUTING.md", "cla_or_dco": "dco"},
+}
+
+
+@pytest.fixture
+def db(tmp_path):
+    conn = store.connect(tmp_path / "p.db")
+    store.init_exchange_schema(conn)
+    conn.execute(
+        "INSERT INTO exchange(exchange_id, external_repo_node_id, external_repo, "
+        "state, created_at, updated_at, data_json) VALUES(?,?,?,?,?,?, '{}')",
+        ("ex_R_1", "R_1", "astral-sh/ruff", "MAPPED", "t", "t"),
+    )
+    conn.commit()
+    DOSSIER["_exchange_id"] = "ex_R_1"
+    yield conn
+    conn.close()
+
+
+def test_plan_candidate_requires_evidence_kind(db):
+    with pytest.raises(InvalidCandidate):
+        plan_candidate(db, DOSSIER, kind="random-idea", rationale="x")
+
+
+def test_plan_candidate_persists_and_advances(db):
+    cand = plan_candidate(db, DOSSIER, kind="missing-test-or-fixture",
+                          rationale="upstream lacks a fixture we needed while integrating")
+    assert cand.contribution_score > 0
+    assert store.counts(db)["contribution_candidate"] == 1
+    row = store.get_exchange(db, "ex_R_1")
+    assert row["state"] == "CONTRIBUTION_CANDIDATE"
+
+
+def test_a2_default_prepares_never_submits():
+    policy = ContributionPolicy()  # A2 default
+    decision = authorize_submit(policy, external_repo="astral-sh/ruff",
+                                kind="documentation-ambiguity", checks_passing=True)
+    assert decision.allowed is False
+    assert decision.requires_human is True
+
+
+def test_a3_allows_only_with_human_approval():
+    policy = ContributionPolicy(autonomy=AutonomyLevel.SUBMIT_WITH_APPROVAL)
+    assert not authorize_submit(policy, external_repo="a/b", kind="documentation-ambiguity",
+                                checks_passing=True).allowed
+    assert authorize_submit(policy, external_repo="a/b", kind="documentation-ambiguity",
+                            human_approved=True, checks_passing=True).allowed
+
+
+def test_a4_allowlist_low_risk_only():
+    policy = ContributionPolicy(autonomy=AutonomyLevel.ALLOWLISTED,
+                                allowlist={"astral-sh/ruff"})
+    # allowlisted + low-risk + checks -> allowed
+    assert authorize_submit(policy, external_repo="astral-sh/ruff",
+                            kind="documentation-ambiguity", checks_passing=True).allowed
+    # allowlisted but NOT low-risk -> blocked
+    assert not authorize_submit(policy, external_repo="astral-sh/ruff",
+                                kind="scoped-feature", checks_passing=True).allowed
+    # low-risk but NOT allowlisted -> blocked
+    assert not authorize_submit(policy, external_repo="other/repo",
+                                kind="documentation-ambiguity", checks_passing=True).allowed
+
+
+def test_duplicate_and_cap_block_submission():
+    policy = ContributionPolicy(autonomy=AutonomyLevel.SUBMIT_WITH_APPROVAL)
+    assert not authorize_submit(policy, external_repo="a/b", kind="documentation-ambiguity",
+                                human_approved=True, checks_passing=True,
+                                duplicate_exists=True).allowed
+    assert not authorize_submit(policy, external_repo="a/b", kind="documentation-ambiguity",
+                                human_approved=True, checks_passing=True, open_prs=3).allowed
+
+
+def test_full_outbound_slice_prepares_then_gated_submit_then_backflow(db):
+    cand = plan_candidate(db, DOSSIER, kind="missing-test-or-fixture",
+                          rationale="missing fixture found during integration")
+    ws = plan_workspace("astral-sh/ruff", "abc1234def")
+    assert ws.executed is False  # dry-run: nothing forked/cloned
+    val = plan_validation(ws, manifests=["pyproject.toml"], reproduction="repro steps")
+    assert val.executed is False
+    packet = build_packet(cand, DOSSIER, ws, val)
+    assert packet["default_posture"] == "prepared-not-submitted"
+    prepare(db, cand, packet)
+    assert store.get_exchange(db, "ex_R_1")["state"] == "PATCH_PREPARED"
+
+    # A2 default -> not submitted (prepared only).
+    a2 = submit(db, ContributionPolicy(), cand, packet)
+    assert a2["submitted"] is False
+    assert a2["requires_human"] is True
+
+    # A3 approved, execute=False -> authorized but not executed.
+    a3 = submit(db, ContributionPolicy(autonomy=AutonomyLevel.SUBMIT_WITH_APPROVAL),
+                cand, packet, human_approved=True, checks_passing=True, execute=False)
+    assert a3["allowed"] is True
+    assert a3["submitted"] is False
+    assert store.get_exchange(db, "ex_R_1")["state"] == "HUMAN_APPROVED"
+
+    # Metabolize the (declined) outcome through the seven organs -> BACKFLOW_COMPLETE.
+    signals = metabolize_exchange(db, exchange_id="ex_R_1", external_repo="astral-sh/ruff",
+                                  outcome="declined", title="add missing fixture")
+    organs = {s.organ_key for s in signals}
+    assert "VI" in organs  # community capital is always produced
+    assert store.counts(db)["backflow_signal"] == len(signals)
+    assert store.get_exchange(db, "ex_R_1")["state"] == "BACKFLOW_COMPLETE"

--- a/tests/test_portal_state_machine.py
+++ b/tests/test_portal_state_machine.py
@@ -1,0 +1,55 @@
+"""BIFRONS portal exchange lifecycle state machine."""
+
+from __future__ import annotations
+
+import pytest
+
+from organvm_engine.portal.state_machine import (
+    ExchangeState,
+    InvalidTransition,
+    PortalStateMachine,
+)
+
+
+def test_shared_prefix_then_fork():
+    sm = PortalStateMachine
+    assert sm.can_advance(ExchangeState.STARRED, ExchangeState.INDEXED)
+    assert sm.can_advance(ExchangeState.MAPPED, ExchangeState.ABSORPTION_CANDIDATE)
+    assert sm.can_advance(ExchangeState.MAPPED, ExchangeState.CONTRIBUTION_CANDIDATE)
+
+
+def test_illegal_transition_raises():
+    with pytest.raises(InvalidTransition):
+        PortalStateMachine.advance(ExchangeState.STARRED, ExchangeState.MERGED)
+
+
+def test_outbound_branch_reaches_backflow():
+    sm = PortalStateMachine
+    path = [
+        ExchangeState.CONTRIBUTION_CANDIDATE,
+        ExchangeState.UPSTREAM_POLICY_CHECKED,
+        ExchangeState.REPRODUCED,
+        ExchangeState.PATCH_PREPARED,
+        ExchangeState.HUMAN_APPROVED,
+        ExchangeState.UPSTREAM_SUBMITTED,
+        ExchangeState.MERGED,
+        ExchangeState.BACKFLOW_COMPLETE,
+    ]
+    for a, b in zip(path, path[1:], strict=True):
+        assert sm.advance(a, b) == b
+
+
+def test_external_write_requires_human_approval_predecessor():
+    # The only edge into UPSTREAM_SUBMITTED comes from HUMAN_APPROVED.
+    assert PortalStateMachine.can_advance(
+        ExchangeState.HUMAN_APPROVED, ExchangeState.UPSTREAM_SUBMITTED,
+    )
+    assert not PortalStateMachine.can_advance(
+        ExchangeState.PATCH_PREPARED, ExchangeState.UPSTREAM_SUBMITTED,
+    )
+    assert PortalStateMachine.requires_human_approval(ExchangeState.UPSTREAM_SUBMITTED)
+
+
+def test_backflow_is_terminal():
+    assert PortalStateMachine.is_terminal(ExchangeState.BACKFLOW_COMPLETE)
+    assert not PortalStateMachine.is_terminal(ExchangeState.MAPPED)

--- a/tests/test_portal_state_machine.py
+++ b/tests/test_portal_state_machine.py
@@ -35,7 +35,7 @@ def test_outbound_branch_reaches_backflow():
         ExchangeState.MERGED,
         ExchangeState.BACKFLOW_COMPLETE,
     ]
-    for a, b in zip(path, path[1:], strict=True):
+    for a, b in zip(path, path[1:], strict=False):
         assert sm.advance(a, b) == b
 
 

--- a/tests/test_resonance.py
+++ b/tests/test_resonance.py
@@ -1,0 +1,81 @@
+"""BIFRONS resonance scoring — lenses + the two independent scores."""
+
+from __future__ import annotations
+
+from organvm_engine.network.resonance import (
+    InternalRepo,
+    absorption_score,
+    compute_resonance,
+    contribution_score,
+)
+
+DOSSIER = {
+    "external_repo": "astral-sh/ruff",
+    "github_node_id": "R_1",
+    "snapshot_ref": "abc1234",
+    "identity": {
+        "description": "An extremely fast Python linter and code formatter",
+        "topics": ["python", "linter", "static-analysis"],
+        "primary_language": "Rust",
+        "languages": {"Rust": 0.9, "Python": 0.1},
+    },
+    "state": {"archived": False, "fork": False, "last_push_at": "2026-07-01T00:00:00Z"},
+    "contracts": {"license": {"spdx": "MIT", "class": "permissive"},
+                  "decision": "code-adaptation-with-attribution",
+                  "contributing": "CONTRIBUTING.md", "cla_or_dco": "dco"},
+}
+
+
+def test_technical_lens_on_shared_language():
+    internal = [InternalRepo("organvm-engine", languages={"Python", "Rust"},
+                             topics={"linter"}, description="python quality control")]
+    edges = compute_resonance(DOSSIER, internal)
+    lenses = {e.lens for e in edges}
+    assert "technical" in lenses
+    tech = next(e for e in edges if e.lens == "technical")
+    assert tech.score > 0
+    assert any("language" in ev for ev in tech.evidence)
+
+
+def test_parallel_and_kinship_lenses():
+    internal = [InternalRepo("a-i--skills", topics={"linter", "static-analysis"},
+                             description="a linter and code formatter with conventions")]
+    edges = compute_resonance(DOSSIER, internal)
+    lenses = {e.lens for e in edges}
+    assert "parallel" in lenses  # shared topics
+    assert "kinship" in lenses   # shared description words (linter, code, formatter)
+
+
+def test_no_edges_below_threshold():
+    internal = [InternalRepo("unrelated", languages={"COBOL"}, topics={"banking"},
+                             description="mainframe payroll batch jobs")]
+    edges = compute_resonance(DOSSIER, internal)
+    assert edges == []
+
+
+def test_absorption_score_higher_for_permissive_active_repo():
+    internal = [InternalRepo("organvm-engine", languages={"Rust", "Python"},
+                             topics={"linter"}, description="python quality control")]
+    edges = compute_resonance(DOSSIER, internal)
+    score = absorption_score(DOSSIER, edges)
+    assert 0.0 < score <= 1.0
+
+    archived = {**DOSSIER, "state": {**DOSSIER["state"], "archived": True}}
+    assert absorption_score(archived, edges) < score
+
+
+def test_contribution_score_penalizes_cla_and_rewards_dco():
+    dco = contribution_score(DOSSIER, has_verified_friction=True, existing_evidence=True)
+    cla_dossier = {**DOSSIER, "contracts": {**DOSSIER["contracts"], "cla_or_dco": "cla"}}
+    cla = contribution_score(cla_dossier, has_verified_friction=True, existing_evidence=True)
+    assert dco > cla
+
+
+def test_scores_are_independent():
+    # A permissive, healthy repo can be great material yet a poor contribution
+    # target if there is no verified friction.
+    internal = [InternalRepo("organvm-engine", languages={"Rust"}, description="linting")]
+    edges = compute_resonance(DOSSIER, internal)
+    absorb = absorption_score(DOSSIER, edges)
+    contrib = contribution_score(DOSSIER, has_verified_friction=False)
+    assert absorb != contrib

--- a/tests/test_star_importer.py
+++ b/tests/test_star_importer.py
@@ -1,0 +1,125 @@
+"""BIFRONS star importer — dossiers -> resonance edges -> MAPPED + convergence."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from organvm_engine.network import ENGAGEMENT_FORMS
+from organvm_engine.network.convergence import find_convergences
+from organvm_engine.network.resonance import InternalRepo
+from organvm_engine.network.star_importer import import_stars, mirror_entries_for_internal
+from organvm_engine.portal import store
+
+
+def _seed_portal(path, dossiers):
+    """Create the alchemia-written tables and insert dossiers + exchange rows."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(store.EXCHANGE_DDL)
+    conn.execute(
+        "CREATE TABLE dossier (id INTEGER PRIMARY KEY AUTOINCREMENT, node_id TEXT, "
+        "full_name TEXT, level TEXT, schema_version TEXT, snapshot_ref TEXT, "
+        "snapshot_at TEXT, doc_json TEXT, exchange_id TEXT, UNIQUE(node_id, level))",
+    )
+    for d in dossiers:
+        ex_id = f"ex_{d['github_node_id']}"
+        conn.execute(
+            "INSERT INTO exchange(exchange_id, external_repo_node_id, external_repo, "
+            "state, created_at, updated_at, data_json) VALUES(?,?,?,?,?,?, '{}')",
+            (ex_id, d["github_node_id"], d["external_repo"], "STARRED",
+             "2026-07-01T00:00:00Z", "2026-07-01T00:00:00Z"),
+        )
+        conn.execute(
+            "INSERT INTO dossier(node_id, full_name, level, schema_version, "
+            "snapshot_ref, snapshot_at, doc_json, exchange_id) VALUES(?,?,?,?,?,?,?,?)",
+            (d["github_node_id"], d["external_repo"], "S1", "1.0",
+             d.get("snapshot_ref", ""), "2026-07-01T00:00:00Z", json.dumps(d), ex_id),
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _dossier(node, full_name, *, lang="Rust", topics=None, desc=""):
+    return {
+        "external_repo": full_name,
+        "github_node_id": node,
+        "snapshot_ref": "abc1234def",
+        "identity": {"description": desc, "topics": topics or [],
+                     "primary_language": lang, "languages": {lang: 1.0}},
+        "state": {"archived": False, "fork": False, "last_push_at": "2026-07-01T00:00:00Z"},
+        "contracts": {"license": {"spdx": "MIT", "class": "permissive"},
+                      "decision": "code-adaptation-with-attribution"},
+    }
+
+
+@pytest.fixture
+def db(tmp_path):
+    _seed_portal(tmp_path / "p.db", [
+        _dossier("R_1", "astral-sh/ruff", lang="Rust",
+                 topics=["python", "linter"], desc="fast python linter"),
+        _dossier("R_2", "psf/black", lang="Python",
+                 topics=["python", "formatter"], desc="python code formatter"),
+    ])
+    conn = store.connect(tmp_path / "p.db")
+    yield conn
+    conn.close()
+
+
+INTERNAL = [
+    InternalRepo("organvm-engine", languages={"Python", "Rust"},
+                 topics={"linter"}, description="python quality control and linting"),
+    InternalRepo("a-i--skills", languages={"Python"},
+                 topics={"python", "formatter"}, description="python code formatting skills"),
+]
+
+
+def test_import_stars_writes_edges_and_maps_exchange(db):
+    summary = import_stars(db, INTERNAL)
+    assert summary.dossiers == 2
+    assert summary.edges > 0
+    assert summary.mapped == 2
+    # Exchanges advanced to MAPPED with scores recorded.
+    row = db.execute("SELECT state, data_json FROM exchange WHERE external_repo=?",
+                     ("astral-sh/ruff",)).fetchone()
+    assert row["state"] == "MAPPED"
+    assert "absorption_score" in json.loads(row["data_json"])
+
+
+def test_import_stars_is_idempotent(db):
+    import_stars(db, INTERNAL)
+    first = store.counts(db)["resonance_edge"]
+    import_stars(db, INTERNAL)
+    assert store.counts(db)["resonance_edge"] == first  # UNIQUE upsert, no dupes
+
+
+def test_convergence_detects_multi_repo_stars(db):
+    import_stars(db, INTERNAL)
+    convs = find_convergences(db, min_repos=2)
+    # ruff resonates with both internal repos (python+linter / python).
+    names = {c.external_repo for c in convs}
+    assert "astral-sh/ruff" in names
+
+
+def test_mirror_entries_projection_feeds_network_map(db):
+    import_stars(db, INTERNAL)
+    mirrors = mirror_entries_for_internal(db, "organvm-engine")
+    assert any(mirrors[lens] for lens in ("technical", "parallel", "kinship"))
+    # Every projected MirrorEntry uses a canonical engagement form.
+    for lens in mirrors.values():
+        for entry in lens:
+            assert set(entry.engagement) <= ENGAGEMENT_FORMS
+
+
+def test_scanner_engagement_forms_are_canonical():
+    # The watch->presence drift fix: scanner/discover emit only canonical forms.
+    from pathlib import Path
+
+    import organvm_engine.network as net
+    net_dir = Path(net.__file__).parent
+    for fname in ("scanner.py", "discover.py"):
+        text = (net_dir / fname).read_text()
+        assert '"watch"' not in text
+        assert '"discussions"' not in text


### PR DESCRIPTION
## BIFRONS — the portal engine (compile / decide / execute / backflow)

The engine half of the **BIFRONS** star↔contribution portal (Janus, two-faced — distinct from IANVA, the MCP doorway). Consumes the shared `portal.db` written by alchemia's star intake and turns absorbed dossiers into relationships, inbound proposals, gated outbound contributions, and seven-organ backflow.

### network/
- `star_importer.py` — compile dossiers → resonance edges; advance each exchange to `MAPPED`. **Feeds** the existing `mapper`/`network-map.yaml` machinery (doesn't duplicate it).
- `resonance.py` — **two independent scores** (absorption vs contribution, never collapsed) across three lenses (technical/parallel/kinship). Configurable heuristic weights.
- `convergence.py` — cross-organ convergence (one star → many internal repos).
- **Fix:** the confirmed `watch`→`presence` vocab drift in `scanner.py` (5 sites) + `discover.py` (2); all engagement forms are now canonical (`presence/contribution/dialogue/invitation`), asserted by a test.

### portal/ (new package)
- `store.py` — engine half of the shared `portal.db` (exchange-owned tables + the **byte-identical** `exchange` spine DDL).
- `models.py` / `proposals.py` — **license-gated** inbound transmutation proposals (never a silent code transplant; abstraction level bounded by the firewall).
- `state_machine.py` — the exchange lifecycle FSM. The **only** edge into `UPSTREAM_SUBMITTED` (the external write) comes from `HUMAN_APPROVED`.

### contrib/
- `policy.py` — autonomy **A0–A4, default A2 = prepare-never-submit**; allowlist + caps; `authorize_submit` is the single external-write gate.
- `planner.py` / `worktree.py` / `validator.py` / `executor.py` — evidence-driven candidate → ephemeral pinned workspace (dry-run) → upstream checks → contribution packet → **policy-gated** submit.
- `backflow.py` — `metabolize_exchange` **reuses** `classify_contribution` to route an outcome through the seven organs → `BACKFLOW_COMPLETE`.

CLI: `organvm portal status|import-stars|convergences|propose`.

### Verified
- 23 new tests incl. the full outbound slice (candidate → packet → gated-submit → backflow); existing network+contrib suites **160 passing** (no regressions); ruff clean
- **Live cross-repo proof**: real star dossiers built via `gh` compiled into resonance edges against ORGANVM repos (e.g. `BehiSecc/awesome-claude-skills` → `a-i--skills` kinship 0.286)

Completes the cross-repo BIFRONS build (alchemia #11 intake; ontologia #17 graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)