### PR TITLE
feat(bifrons): loop-driving CLI verbs + autopoietic metabolize effector + done.sh

### DIFF
--- a/done.sh
+++ b/done.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# BIFRONS — Epic 6 acceptance predicate (the two-way proof).
+#
+# Definition of Done (charter): executable, idempotent, exit 0 <=> done. This
+# drives ONE star's exchange through the WHOLE portal loop and asserts the
+# single-exchange_id thread across both faces, plus the human-gate boundary.
+#
+#   star -> dossier -> [inbound] proposal -> draft internal PR
+#                   -> [outbound] candidate -> packet -> submit(gated) -> backflow
+#
+# Core is deterministic + offline (seeded exchange) so it runs anywhere,
+# including engine CI. Set BIFRONS_LIVE=1 (with an authenticated gh) to also run
+# the real 419-star alchemia intake as a live augment (non-fatal on infra error).
+#
+# Usage:  bash done.sh
+set -euo pipefail
+
+REPO="acme/widget"
+NODE="MDEwOlJlcG9zaXRvcnkxMjM0"
+export WORK="$(mktemp -d)"
+export BIFRONS_DB="$WORK/portal.db"
+PROPOSALS="$WORK/proposals"
+BACKFLOW="$WORK/backflow"
+trap 'rm -rf "$WORK"' EXIT
+
+say() { printf '\n=== %s ===\n' "$*"; }
+die() { printf '\nDONE.SH FAILED: %s\n' "$*" >&2; exit 1; }
+
+command -v organvm >/dev/null 2>&1 || die "organvm CLI not on PATH (pip install -e .)"
+
+# --- 0. Seed the intake (alchemia's real schema if importable, else raw SQL) ---
+say "0. seed intake — one exchange + S1 dossier"
+python3 - "$REPO" "$NODE" <<'PY'
+import json, os, sqlite3, sys
+repo, node = sys.argv[1], sys.argv[2]
+db = os.environ["BIFRONS_DB"]
+from organvm_engine.portal import store
+conn = store.connect(db)
+store.init_exchange_schema(conn)  # exchange spine + engine tables
+conn.execute("""
+CREATE TABLE IF NOT EXISTS dossier (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, node_id TEXT NOT NULL,
+    full_name TEXT NOT NULL, level TEXT NOT NULL, doc_json TEXT NOT NULL,
+    exchange_id TEXT DEFAULT '', UNIQUE(node_id, level))
+""")
+exid = "01EXCHANGEDONESH0000000001"
+doc = {
+    "external_repo": repo, "snapshot_ref": "abc1234567deadbeefcafe",
+    "identity": {"primary_language": "Python", "languages": {"Python": 1.0},
+                 "topics": ["cli", "tools"], "description": "A widget library."},
+    "state": {"archived": False, "last_push_at": "2026-01-01T00:00:00Z"},
+    "contracts": {"decision": "idea-or-interface-only-unless-obligations-accepted",
+                  "license": {"spdx": "MIT"}, "contributing": "CONTRIBUTING.md", "cla_or_dco": "dco"},
+    "architecture": {"manifests": ["pyproject.toml"], "test_strategy": ["pytest"]},
+    "provenance": {"hashes": {"README.md": "deadbeef"}},
+}
+conn.execute("INSERT OR IGNORE INTO exchange(exchange_id, external_repo_node_id, external_repo,"
+             " state, created_at, updated_at, data_json) VALUES(?,?,?,?,?,?,?)",
+             (exid, node, repo, "MAPPED", store.now_iso(), store.now_iso(), "{}"))
+conn.execute("INSERT OR IGNORE INTO dossier(node_id, full_name, level, doc_json, exchange_id)"
+             " VALUES(?,?,?,?,?)", (node, repo, "S1", json.dumps(doc), exid))
+conn.commit(); conn.close()
+print(f"  seeded exchange {exid} + dossier for {repo}")
+PY
+
+# --- 1. Inbound face: proposal -> draft internal PR (no default-branch write) ---
+say "1. inbound: propose -> prepare (draft internal PR)"
+organvm portal propose "$REPO" organvm-engine
+organvm portal prepare "$REPO" --out-dir "$PROPOSALS"
+[ -f "$PROPOSALS/01EXCHANGEDONESH0000000001.md" ] || die "draft internal PR artifact missing"
+
+# --- 2. Outbound face: candidate -> packet (nothing sent) ---
+say "2. outbound: candidate -> package (prepared, not submitted)"
+organvm portal candidate "$REPO" --kind documentation-ambiguity \
+  --rationale "README setup step is ambiguous; a one-line fix removes the ambiguity."
+organvm portal package "$REPO"
+
+# --- 3. The human gate: default A2 must REFUSE the external write ---
+say "3. gate: default submit must refuse (A2 = prepare, never submit)"
+GATE_OUT="$(organvm portal submit "$REPO")"
+printf '%s\n' "$GATE_OUT"
+printf '%s' "$GATE_OUT" | grep -q "allowed: False" || die "A2 default did not refuse the submit"
+printf '%s' "$GATE_OUT" | grep -q "requires_human" || die "gate did not flag requires_human"
+
+# --- 4. Approval reaches HUMAN_APPROVED but opens NO PR (no --execute) ---
+say "4. gate: --approve --checks-passing reaches HUMAN_APPROVED, opens no PR"
+organvm portal submit "$REPO" --approve --checks-passing
+
+# --- 5. Seven-organ backflow -> BACKFLOW_COMPLETE ---
+say "5. backflow: metabolize outcome through the seven organs"
+organvm portal backflow "$REPO" --outcome dormant --write --out-dir "$BACKFLOW"
+[ -f "$BACKFLOW/backflow-manifest.yaml" ] || die "backflow manifest missing"
+
+# --- 6. Assertions: the thread + the gate held ---
+say "6. assert: one exchange_id threads the whole loop; nothing was sent"
+python3 - <<'PY'
+import os, sqlite3, sys
+db = os.environ["BIFRONS_DB"]
+conn = sqlite3.connect(db); conn.row_factory = sqlite3.Row
+exid = "01EXCHANGEDONESH0000000001"
+def one(q, *a): return conn.execute(q, a).fetchone()[0]
+fails = []
+# terminal state
+st = one("SELECT state FROM exchange WHERE exchange_id=?", exid)
+if st != "BACKFLOW_COMPLETE": fails.append(f"exchange state {st} != BACKFLOW_COMPLETE")
+# nothing sent — the external write never happened
+n_up = one("SELECT COUNT(*) FROM upstream_interaction WHERE exchange_id=?", exid)
+if n_up != 0: fails.append(f"upstream_interaction={n_up} (expected 0 — nothing sent)")
+# both faces + backflow all carry the one exchange_id
+for t in ("transmutation_proposal", "contribution_candidate", "backflow_signal"):
+    n = one(f"SELECT COUNT(*) FROM {t} WHERE exchange_id=?", exid)  # noqa: S608
+    if n < 1: fails.append(f"{t} has no row threaded to exchange {exid}")
+# proposal was realized (its own status advanced to pr_open)
+pst = one("SELECT status FROM transmutation_proposal WHERE exchange_id=?", exid)
+if pst != "pr_open": fails.append(f"proposal status {pst} != pr_open")
+# backflow generated at least the community + distribution signals
+n_bf = one("SELECT COUNT(*) FROM backflow_signal WHERE exchange_id=?", exid)
+if n_bf < 2: fails.append(f"backflow_signal={n_bf} (expected >=2)")
+conn.close()
+if fails:
+    print("  THREAD ASSERTIONS FAILED:"); [print("   -", f) for f in fails]; sys.exit(1)
+print(f"  exchange {exid}: BACKFLOW_COMPLETE, 0 sent, {n_bf} backflow signals, thread intact")
+PY
+
+# --- 6b. Autopoietic beat: one bounded metabolize writes the observable surface ---
+say "6b. metabolize: one autopoietic beat (absorb->map->prepare->surface), never submits"
+organvm portal metabolize --no-absorb --budget 5 --state-dir "$WORK/state" --db "$BIFRONS_DB"
+[ -f "$WORK/state/state.json" ] || die "metabolize state surface missing"
+python3 - <<'PY'
+import json, os, sqlite3, sys
+d = json.load(open(os.path.join(os.environ["WORK"], "state", "state.json")))
+for key in ("generated_at", "exchanges_by_state", "prepared_awaiting_gate", "last_run_seconds"):
+    if key not in d:
+        print(f"  state surface missing key: {key}"); sys.exit(1)
+# The beat must never send: no external-write record exists.
+conn = sqlite3.connect(os.environ["BIFRONS_DB"])
+n_up = conn.execute("SELECT COUNT(*) FROM upstream_interaction").fetchone()[0]
+conn.close()
+if n_up != 0:
+    print(f"  metabolize sent something (upstream_interaction={n_up})"); sys.exit(1)
+print(f"  state surface observable: awaiting_gate={d['prepared_awaiting_gate']}, "
+      f"states={d['exchanges_by_state']}, 0 sent")
+PY
+
+# --- 7. Optional live augment: real 419-star intake (non-fatal on infra) ---
+if [ "${BIFRONS_LIVE:-0}" = "1" ]; then
+  say "7. live augment: real alchemia star intake (BIFRONS_LIVE=1)"
+  if command -v alchemia >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    if alchemia stars sync; then
+      N1="$(python3 -c "import os,sqlite3;print(sqlite3.connect(os.environ['BIFRONS_DB']).execute('SELECT COUNT(*) FROM external_repo').fetchone()[0])")"
+      alchemia stars sync    # idempotency: re-run should add no new external_repo rows
+      N2="$(python3 -c "import os,sqlite3;print(sqlite3.connect(os.environ['BIFRONS_DB']).execute('SELECT COUNT(*) FROM external_repo').fetchone()[0])")"
+      [ "$N1" = "$N2" ] || die "star sync not idempotent ($N1 -> $N2)"
+      echo "  live: $N2 real stars synced, idempotent re-run confirmed"
+      organvm portal import-stars || true
+    else
+      echo "  live: alchemia stars sync failed (network/gh) — skipping augment (non-fatal)"
+    fi
+  else
+    echo "  live: alchemia or gh unavailable — skipping augment (non-fatal)"
+  fi
+else
+  say "7. live augment skipped (set BIFRONS_LIVE=1 with an authenticated gh to run it)"
+fi
+
+printf '\nBIFRONS Epic-6 two-way proof passed — one exchange_id threaded star->backflow, gate held.\n'

--- a/src/organvm_engine/cli/__init__.py
+++ b/src/organvm_engine/cli/__init__.py
@@ -229,10 +229,16 @@ from organvm_engine.cli.plans import (
     cmd_plans_tidy,
 )
 from organvm_engine.cli.portal import (
+    cmd_portal_backflow,
+    cmd_portal_candidate,
     cmd_portal_convergences,
     cmd_portal_import_stars,
+    cmd_portal_metabolize,
+    cmd_portal_package,
+    cmd_portal_prepare,
     cmd_portal_propose,
     cmd_portal_status,
+    cmd_portal_submit,
 )
 from organvm_engine.cli.primitives import (
     cmd_primitive_guardian_add_watch,
@@ -2248,6 +2254,85 @@ def build_parser() -> argparse.ArgumentParser:
     portal_prop.add_argument("target", help="Target ORGANVM repo")
     portal_prop.add_argument("--db", default=None, help="Portal DB path")
 
+    portal_prepare = portal_sub.add_parser(
+        "prepare", help="Inbound: realize the proposal as a draft internal PR",
+    )
+    portal_prepare.add_argument("external", help="External repo (owner/name)")
+    portal_prepare.add_argument("--db", default=None, help="Portal DB path")
+    portal_prepare.add_argument(
+        "--out-dir", dest="out_dir", default=None, help="Draft-PR artifact directory",
+    )
+
+    portal_cand = portal_sub.add_parser(
+        "candidate", help="Outbound: evidence -> contribution candidate",
+    )
+    portal_cand.add_argument("external", help="External repo (owner/name)")
+    portal_cand.add_argument(
+        "--kind", required=True,
+        help="Contribution kind (reproducible-defect, documentation-ambiguity, ...)",
+    )
+    portal_cand.add_argument("--rationale", required=True, help="Evidence-driven rationale")
+    portal_cand.add_argument("--tractability", type=float, default=0.5)
+    portal_cand.add_argument("--testability", type=float, default=0.5)
+    portal_cand.add_argument("--db", default=None, help="Portal DB path")
+
+    portal_pkg = portal_sub.add_parser(
+        "package", help="Outbound: worktree + checks -> prepared packet (sends nothing)",
+    )
+    portal_pkg.add_argument("external", help="External repo (owner/name)")
+    portal_pkg.add_argument("--ref", default=None, help="Pinned upstream ref (default: snapshot)")
+    portal_pkg.add_argument("--db", default=None, help="Portal DB path")
+
+    portal_submit = portal_sub.add_parser(
+        "submit", help="The single human-gated external-write boundary (A2: never submits)",
+    )
+    portal_submit.add_argument("external", help="External repo (owner/name)")
+    portal_submit.add_argument(
+        "--approve", action="store_true", help="Human approval (escalates to A3)",
+    )
+    portal_submit.add_argument(
+        "--checks-passing", dest="checks_passing", action="store_true",
+        help="Assert upstream checks passed (required with --approve to authorize)",
+    )
+    portal_submit.add_argument(
+        "--execute", action="store_true",
+        help="Actually open the upstream PR (the irreversible external write)",
+    )
+    portal_submit.add_argument("--db", default=None, help="Portal DB path")
+
+    portal_bf = portal_sub.add_parser(
+        "backflow", help="Seven-organ backflow -> BACKFLOW_COMPLETE",
+    )
+    portal_bf.add_argument("external", help="External repo (owner/name)")
+    portal_bf.add_argument(
+        "--outcome", default="dormant", choices=["merged", "declined", "dormant"],
+        help="Exchange outcome to metabolize (default: dormant)",
+    )
+    portal_bf.add_argument("--write", action="store_true", help="Write the backflow manifest")
+    portal_bf.add_argument(
+        "--out-dir", dest="out_dir", default=None, help="Manifest output directory",
+    )
+    portal_bf.add_argument("--db", default=None, help="Portal DB path")
+
+    portal_meta = portal_sub.add_parser(
+        "metabolize", help="One bounded beat: absorb -> map -> prepare -> surface (never submits)",
+    )
+    portal_meta.add_argument("--budget", type=int, default=5, help="Max new stars/exchanges per beat")
+    portal_meta.add_argument(
+        "--threshold", type=float, default=0.15, help="Min resonance score to auto-prepare",
+    )
+    portal_meta.add_argument(
+        "--no-absorb", dest="no_absorb", action="store_true",
+        help="Skip the alchemia star-sync/dossier step (map + prepare only)",
+    )
+    portal_meta.add_argument(
+        "--state-dir", dest="state_dir", default=None, help="State-surface directory",
+    )
+    portal_meta.add_argument(
+        "--out-dir", dest="out_dir", default=None, help="Draft-PR artifact directory",
+    )
+    portal_meta.add_argument("--db", default=None, help="Portal DB path")
+
     # trivium — dialectica universalis
     trv = sub.add_parser(
         "trivium",
@@ -3583,6 +3668,12 @@ def main() -> int:
             "import-stars": cmd_portal_import_stars,
             "convergences": cmd_portal_convergences,
             "propose": cmd_portal_propose,
+            "prepare": cmd_portal_prepare,
+            "candidate": cmd_portal_candidate,
+            "package": cmd_portal_package,
+            "submit": cmd_portal_submit,
+            "backflow": cmd_portal_backflow,
+            "metabolize": cmd_portal_metabolize,
         }
         handler = portal_dispatch.get(getattr(args, "subcommand", "") or "")
         if handler:

--- a/src/organvm_engine/cli/portal.py
+++ b/src/organvm_engine/cli/portal.py
@@ -5,8 +5,20 @@
     organvm portal convergences [--min-repos N] Cross-organ convergence points
     organvm portal propose <external> <target>  Generate a transmutation proposal
 
+  Loop-driving verbs (the exchange lifecycle, end to end):
+
+    organvm portal prepare  <external>          Inbound: proposal -> draft internal PR
+    organvm portal candidate <external> --kind K --rationale R
+                                                Outbound: evidence -> contribution candidate
+    organvm portal package  <external>          Outbound: worktree+checks -> prepared packet
+    organvm portal submit   <external> [--approve --checks-passing] [--execute]
+                                                The single human-gated external-write boundary
+    organvm portal backflow <external> --outcome {merged|declined|dormant} [--write]
+                                                Seven-organ backflow -> BACKFLOW_COMPLETE
+
 BIFRONS (Janus, two-faced) is the star<->contribution portal; distinct from
-IANVA (the MCP doorway).
+IANVA (the MCP doorway). The same starred repo is both absorbed (inbound) and
+contributed-to (outbound); one exchange_id threads the whole traversal.
 """
 
 from __future__ import annotations
@@ -17,7 +29,7 @@ from organvm_engine.network.convergence import convergence_report, find_converge
 from organvm_engine.network.resonance import InternalRepo
 from organvm_engine.network.star_importer import import_stars
 from organvm_engine.portal import store
-from organvm_engine.portal.proposals import propose_transmutation
+from organvm_engine.portal.proposals import prepare_internal_pr, propose_transmutation
 
 
 def _internal_repos_from_registry() -> list[InternalRepo]:
@@ -110,4 +122,271 @@ def cmd_portal_propose(args: argparse.Namespace) -> int:
     print(f"  finding: {proposal.finding}")
     print(f"  proposed: {proposal.proposed_change}")
     conn.close()
+    return 0
+
+
+def cmd_portal_prepare(args: argparse.Namespace) -> int:
+    """Inbound: realize the latest transmutation proposal as a draft internal PR."""
+    conn = store.connect(getattr(args, "db", None))
+    store.init_exchange_schema(conn)
+    proposal = store.get_latest_proposal(conn, args.external)
+    if proposal is None:
+        print(f"  no transmutation proposal for {args.external} — run 'portal propose' first.")
+        conn.close()
+        return 1
+    artifact, final_state = prepare_internal_pr(
+        conn, proposal, out_dir=getattr(args, "out_dir", None),
+    )
+    print(f"BIFRONS PREPARE (inbound) — {args.external} -> {proposal['target_repo']}")
+    print(f"  exchange: {proposal['exchange_id']}  state: {final_state}")
+    print(f"  draft internal PR: {artifact}")
+    print("  posture: draft-internal-PR-only (no default-branch write)")
+    conn.close()
+    return 0
+
+
+def cmd_portal_candidate(args: argparse.Namespace) -> int:
+    """Outbound: turn dossier evidence into a contribution candidate."""
+    from organvm_engine.contrib.planner import InvalidCandidate, plan_candidate
+
+    conn = store.connect(getattr(args, "db", None))
+    store.init_exchange_schema(conn)
+    dossier = store.get_dossier(conn, args.external)
+    if dossier is None:
+        print(f"  no dossier for {args.external} — run 'alchemia stars dossier' first.")
+        conn.close()
+        return 1
+    try:
+        candidate = plan_candidate(
+            conn, dossier,
+            kind=args.kind,
+            rationale=args.rationale,
+            tractability=getattr(args, "tractability", 0.5),
+            testability=getattr(args, "testability", 0.5),
+        )
+    except InvalidCandidate as exc:
+        print(f"  {exc}")
+        conn.close()
+        return 1
+    print(f"BIFRONS CANDIDATE (outbound) — {candidate.external_repo}")
+    print(f"  kind: {candidate.kind}  score: {candidate.contribution_score:.3f}")
+    print(f"  exchange: {candidate.exchange_id}  status: {candidate.status}")
+    conn.close()
+    return 0
+
+
+def cmd_portal_package(args: argparse.Namespace) -> int:
+    """Outbound: plan an ephemeral workspace + checks and assemble the packet (sends nothing)."""
+    from organvm_engine.contrib.executor import build_packet
+    from organvm_engine.contrib.executor import prepare as prepare_contribution
+    from organvm_engine.contrib.validator import plan_validation
+    from organvm_engine.contrib.worktree import plan_workspace
+
+    conn = store.connect(getattr(args, "db", None))
+    store.init_exchange_schema(conn)
+    candidate = store.get_latest_candidate(conn, args.external)
+    if candidate is None:
+        print(f"  no contribution candidate for {args.external} — run 'portal candidate' first.")
+        conn.close()
+        return 1
+    dossier = store.get_dossier(conn, args.external) or {}
+    ref = getattr(args, "ref", None) or dossier.get("snapshot_ref", "") or "HEAD"
+    workspace = plan_workspace(candidate.external_repo, ref)
+    manifests = dossier.get("architecture", {}).get("manifests", [])
+    validation = plan_validation(
+        workspace, manifests=manifests, reproduction=candidate.rationale,
+    )
+    packet = build_packet(candidate, dossier, workspace, validation)
+    prepare_contribution(conn, candidate, packet)
+    print(f"BIFRONS PACKAGE (outbound) — {candidate.external_repo}")
+    print(f"  workspace: {workspace.worktree_path} @ {workspace.ref}")
+    print(f"  checks: {', '.join(validation.commands)}")
+    print(f"  posture: {packet['default_posture']}  (nothing sent)")
+    print("  exchange advanced to PATCH_PREPARED")
+    conn.close()
+    return 0
+
+
+def cmd_portal_submit(args: argparse.Namespace) -> int:
+    """The single external-write boundary. Default posture A2: prepare, never submit."""
+    from organvm_engine.contrib.executor import submit as submit_contribution
+    from organvm_engine.contrib.policy import AutonomyLevel, ContributionPolicy
+
+    conn = store.connect(getattr(args, "db", None))
+    store.init_exchange_schema(conn)
+    candidate = store.get_latest_candidate(conn, args.external)
+    if candidate is None:
+        print(f"  no contribution candidate for {args.external} — run 'portal package' first.")
+        conn.close()
+        return 1
+    autonomy = (
+        AutonomyLevel.SUBMIT_WITH_APPROVAL if args.approve else AutonomyLevel.PREPARE
+    )
+    policy = ContributionPolicy(autonomy=autonomy)
+    result = submit_contribution(
+        conn, policy, candidate, candidate.packet,
+        human_approved=bool(args.approve),
+        checks_passing=bool(getattr(args, "checks_passing", False)),
+        execute=bool(getattr(args, "execute", False)),
+    )
+    print(f"BIFRONS SUBMIT (gate) — {result['external_repo']}")
+    print(f"  allowed: {result['allowed']}  submitted: {result['submitted']}")
+    print(f"  reason: {result['reason']}")
+    if result.get("requires_human"):
+        print("  requires_human: the external write is the single human-gated atom (A2 default).")
+    if result.get("pr_number"):
+        print(f"  upstream PR: #{result['pr_number']}")
+    conn.close()
+    # A refusal is a valid, successful outcome. Only a requested-but-blocked
+    # external write is an error.
+    if getattr(args, "execute", False) and not result["submitted"]:
+        return 1
+    return 0
+
+
+def cmd_portal_backflow(args: argparse.Namespace) -> int:
+    """Metabolize an exchange outcome through the seven organs -> BACKFLOW_COMPLETE."""
+    from organvm_engine.contrib.backflow import metabolize_exchange
+
+    conn = store.connect(getattr(args, "db", None))
+    store.init_exchange_schema(conn)
+    exchange = store.exchange_for_repo(conn, args.external)
+    if exchange is None:
+        print(f"  no exchange for {args.external}.")
+        conn.close()
+        return 1
+    dossier = store.get_dossier(conn, args.external) or {}
+    language = dossier.get("identity", {}).get("primary_language")
+    signals = metabolize_exchange(
+        conn,
+        exchange_id=exchange["exchange_id"],
+        external_repo=args.external,
+        outcome=args.outcome,
+        title=f"contribution to {args.external}",
+        language=language,
+    )
+    print(f"BIFRONS BACKFLOW — {args.external}  outcome={args.outcome}")
+    print(f"  exchange: {exchange['exchange_id']} -> BACKFLOW_COMPLETE")
+    print(f"  {len(signals)} signals across organs:")
+    for signal in signals:
+        print(f"    ORGAN-{signal.organ_key}: {signal.signal_type.value} — {signal.content}")
+    if getattr(args, "write", False):
+        from pathlib import Path
+
+        from organvm_engine.contrib.backflow import write_backflow_manifest
+
+        report: dict[str, list] = {k: [] for k in ("I", "II", "III", "IV", "V", "VI", "VII")}
+        for signal in signals:
+            report[signal.organ_key].append(signal)
+        out_dir = Path(
+            getattr(args, "out_dir", None) or "~/.organvm/bifrons/backflow",
+        ).expanduser()
+        path = write_backflow_manifest(report, out_dir)
+        print(f"  manifest: {path}")
+    conn.close()
+    return 0
+
+
+def _best_internal_repo(conn, exchange_id: str) -> str:
+    """The highest-resonance internal repo for an exchange (target for absorption)."""
+    row = conn.execute(
+        "SELECT internal_repo FROM resonance_edge WHERE exchange_id=? "
+        "ORDER BY score DESC LIMIT 1",
+        (exchange_id,),
+    ).fetchone()
+    return row["internal_repo"] if row else "organvm-engine"
+
+
+def cmd_portal_metabolize(args: argparse.Namespace) -> int:
+    """One bounded, idempotent BIFRONS beat: absorb -> map -> prepare -> surface.
+
+    The autopoietic effector. Reuses the loop verbs, does the inbound face
+    autonomously (proposals + draft internal PRs), and NEVER submits — the outbound
+    contribution gate stays human-held. Fail-open: a missing alchemia CLI or a slow
+    upstream degrades gracefully; the beat never breaks.
+    """
+    import shutil
+    import subprocess
+    import time
+
+    from organvm_engine.portal.models import PortalHealthSnapshot
+    from organvm_engine.portal.proposals import prepare_internal_pr
+    from organvm_engine.portal.state import write_state
+    from organvm_engine.portal.state_machine import ExchangeState
+
+    started = time.monotonic()
+    db = getattr(args, "db", None)
+    db_path = str(db) if db else str(store.default_db_path())
+    budget = int(getattr(args, "budget", 5) or 5)
+    threshold = float(getattr(args, "threshold", 0.15) or 0.15)
+
+    conn = store.connect(db)
+    store.init_exchange_schema(conn)
+
+    # 1. Absorb: sync new stars + dossier the next N (only if alchemia is present).
+    absorbed = False
+    if not getattr(args, "no_absorb", False) and shutil.which("alchemia"):
+        for cmd in (
+            ["alchemia", "stars", "sync", "--db", db_path],
+            ["alchemia", "stars", "dossier", "--new", "--limit", str(budget), "--db", db_path],
+        ):
+            try:
+                subprocess.run(cmd, check=False, capture_output=True, timeout=300)  # noqa: S603
+                absorbed = True
+            except (OSError, subprocess.SubprocessError):
+                pass
+
+    # 2. Map: dossiers -> resonance edges (idempotent upsert).
+    internal = _internal_repos_from_registry()
+    summary = import_stars(conn, internal)
+
+    # 3. Prepare (inbound only, bounded): auto-realize draft internal PRs for the
+    #    next `budget` high-resonance exchanges still at MAPPED. Converges: each is
+    #    moved off MAPPED, so re-runs pick up only genuinely new stars. Never submits.
+    prepared = 0
+    rows = conn.execute(
+        "SELECT DISTINCT e.exchange_id AS xid, e.external_repo AS repo "
+        "FROM exchange e JOIN resonance_edge r ON r.exchange_id = e.exchange_id "
+        "WHERE e.state = ? AND r.score >= ? LIMIT ?",
+        (ExchangeState.MAPPED.value, threshold, budget),
+    ).fetchall()
+    for row in rows:
+        dossier = store.get_dossier(conn, row["repo"])
+        if not dossier:
+            continue
+        proposal = propose_transmutation(dossier, _best_internal_repo(conn, row["xid"]))
+        store.insert_transmutation_proposal(conn, proposal)
+        latest = store.get_latest_proposal(conn, row["repo"])
+        if latest is not None:
+            prepare_internal_pr(conn, latest, out_dir=getattr(args, "out_dir", None))
+            prepared += 1
+
+    # 4. Surface: write the observable state (organ-health probes this).
+    by_state = {
+        r["state"]: r["n"]
+        for r in conn.execute(
+            "SELECT state, COUNT(*) AS n FROM exchange GROUP BY state",
+        ).fetchall()
+    }
+    awaiting = sum(
+        by_state.get(s.value, 0)
+        for s in (ExchangeState.PATCH_PREPARED, ExchangeState.HUMAN_APPROVED)
+    )
+    snapshot = PortalHealthSnapshot(
+        generated_at=store.now_iso(),
+        stars_absorbed=summary.dossiers,
+        dossiers=summary.dossiers,
+        resonance_edges=summary.edges,
+        proposals_prepared=prepared,
+        prepared_awaiting_gate=awaiting,
+        exchanges_by_state=by_state,
+        last_run_seconds=round(time.monotonic() - started, 3),
+    )
+    state_path = write_state(snapshot, directory=getattr(args, "state_dir", None))
+    conn.close()
+
+    print(f"BIFRONS METABOLIZE — absorbed={'yes' if absorbed else 'skip'}  "
+          f"dossiers={summary.dossiers}  edges={summary.edges}  "
+          f"prepared={prepared}  awaiting_gate={awaiting}")
+    print(f"  state: {state_path}")
     return 0

--- a/src/organvm_engine/portal/models.py
+++ b/src/organvm_engine/portal/models.py
@@ -76,3 +76,25 @@ class ContributionCandidate:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+@dataclass
+class PortalHealthSnapshot:
+    """One BIFRONS metabolize beat, made observable.
+
+    The state surface the beat writes each cycle — what the portal absorbed,
+    mapped, and prepared, plus how many contributions pool awaiting the single
+    human gate. This is the effector's proof-of-life for organ-health.
+    """
+
+    generated_at: str
+    stars_absorbed: int = 0
+    dossiers: int = 0
+    resonance_edges: int = 0
+    proposals_prepared: int = 0
+    prepared_awaiting_gate: int = 0
+    exchanges_by_state: dict[str, int] = field(default_factory=dict)
+    last_run_seconds: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/src/organvm_engine/portal/proposals.py
+++ b/src/organvm_engine/portal/proposals.py
@@ -8,7 +8,26 @@ realized (later, on approval) as a draft internal PR, never a default-branch wri
 
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from organvm_engine.portal import store
 from organvm_engine.portal.models import TransmutationProposal
+from organvm_engine.portal.state_machine import ExchangeState, PortalStateMachine
+
+# The inbound branch, in order — the shared prefix plus the internal-evolution
+# states. ``prepare_internal_pr`` walks an exchange forward along this path.
+_INBOUND_ORDER = [
+    ExchangeState.STARRED,
+    ExchangeState.INDEXED,
+    ExchangeState.DOSSIERED,
+    ExchangeState.MAPPED,
+    ExchangeState.ABSORPTION_CANDIDATE,
+    ExchangeState.INTERNAL_PROPOSAL,
+    ExchangeState.INTERNAL_PREPARED,
+    ExchangeState.INTERNAL_PR_OPEN,
+]
 
 # License decision -> permitted abstraction level + whether code may be copied.
 _ABSTRACTION_BY_DECISION = {
@@ -70,3 +89,98 @@ def propose_transmutation(
         copied_code=may_copy and abstraction == "code",
         status="proposed",
     )
+
+
+def _pfield(proposal: Any, key: str, default: str = "") -> str:
+    """Read a field from a proposal that may be a sqlite3.Row or a dataclass."""
+    if isinstance(proposal, sqlite3.Row):
+        try:
+            return proposal[key] if proposal[key] is not None else default
+        except (IndexError, KeyError):
+            return default
+    return getattr(proposal, key, default)
+
+
+def render_draft_pr(proposal: Any) -> str:
+    """Render a draft *internal* PR body from a transmutation proposal.
+
+    Pure: produces the review document a maintainer reads before the change is
+    realized. It is never a git push — the inbound side never writes a default
+    branch. The document carries the license decision and provenance so the graft
+    is auditable.
+    """
+    klass = _pfield(proposal, "klass")
+    return "\n".join([
+        f"# Transmutation proposal: adopt {klass.replace('-', ' ')}",
+        "",
+        f"- **Source (absorbed):** {_pfield(proposal, 'external_repo')}"
+        f"@{_pfield(proposal, 'source_ref')[:10]}",
+        f"- **Target (ORGANVM):** {_pfield(proposal, 'target_repo')}",
+        f"- **Class:** {klass}",
+        f"- **License decision:** {_pfield(proposal, 'license_decision')}",
+        f"- **Abstraction level:** {_pfield(proposal, 'abstraction_level', 'idea')}",
+        "",
+        "## Finding",
+        _pfield(proposal, "finding"),
+        "",
+        "## Proposed change",
+        _pfield(proposal, "proposed_change"),
+        "",
+        "## Provenance & posture",
+        "- Realized as a **draft internal PR only** — no default-branch write.",
+        "- Attribution + provenance to the source repo are mandatory.",
+        f"- exchange_id: `{_pfield(proposal, 'exchange_id')}`",
+    ])
+
+
+def default_proposals_dir() -> Path:
+    return Path("~/.organvm/bifrons/proposals").expanduser()
+
+
+def prepare_internal_pr(
+    conn: sqlite3.Connection,
+    proposal: Any,
+    *,
+    out_dir: Path | str | None = None,
+) -> tuple[str, str]:
+    """Walk the exchange's inbound branch to INTERNAL_PR_OPEN and write the draft PR.
+
+    The inbound analog of ``contrib.executor.prepare``. Advances the lifecycle
+    through the legal inbound edges (idempotently, validated by the state
+    machine), writes the draft internal-PR review document to ``out_dir``, and
+    marks the proposal's own status ``pr_open``. Returns ``(artifact_path,
+    final_state)``. Performs no git write of any kind.
+    """
+    store.init_exchange_schema(conn)
+    exchange_id = _pfield(proposal, "exchange_id")
+
+    final_state = ""
+    row = store.get_exchange(conn, exchange_id) if exchange_id else None
+    if row is not None:
+        current = row["state"]
+        names = [s.value for s in _INBOUND_ORDER]
+        if current in names:
+            idx = names.index(current)
+            state = _INBOUND_ORDER[idx]
+            for nxt in _INBOUND_ORDER[idx + 1:]:
+                if PortalStateMachine.can_advance(state, nxt):
+                    store.advance_exchange(conn, exchange_id, nxt.value)
+                    state = nxt
+            final_state = state.value
+        else:
+            # The exchange already forked onto the outbound branch — this is a
+            # two-faced (BIFRONS) exchange. Record the inbound artifact without
+            # rewinding the tracked lifecycle state.
+            final_state = current
+
+    directory = Path(out_dir).expanduser() if out_dir else default_proposals_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    safe = (exchange_id or _pfield(proposal, "external_repo").replace("/", "_")) or "proposal"
+    artifact = directory / f"{safe}.md"
+    artifact.write_text(render_draft_pr(proposal))
+
+    pid = _pfield(proposal, "id")
+    if pid:
+        store.set_proposal_status(conn, int(pid), "pr_open")
+
+    return str(artifact), final_state

--- a/src/organvm_engine/portal/state.py
+++ b/src/organvm_engine/portal/state.py
@@ -1,0 +1,47 @@
+"""BIFRONS portal state surface — make the metabolize beat observable.
+
+The metabolize effector writes a ``PortalHealthSnapshot`` here each cycle:
+``state.json`` (always current) plus an append-only ``metabolize.jsonl`` history.
+This is what makes the organ *felt* — organ-health probes the ``state.json`` mtime
+to prove the beat fired, and the beat generator reads it back (past tense).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from organvm_engine.portal.models import PortalHealthSnapshot
+
+
+def state_dir() -> Path:
+    """Where the portal surfaces its state (override ``$BIFRONS_STATE_DIR``)."""
+    env = os.environ.get("BIFRONS_STATE_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path("~/.organvm/bifrons").expanduser()
+
+
+def write_state(
+    snapshot: PortalHealthSnapshot, *, directory: Path | str | None = None,
+) -> Path:
+    """Write the latest snapshot + append it to the history. Returns the state path."""
+    target = Path(directory).expanduser() if directory else state_dir()
+    target.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(snapshot.to_dict(), indent=2)
+    state_path = target / "state.json"
+    state_path.write_text(payload + "\n")
+    with (target / "metabolize.jsonl").open("a") as handle:
+        handle.write(json.dumps(snapshot.to_dict()) + "\n")
+    return state_path
+
+
+def read_state(*, directory: Path | str | None = None) -> dict:
+    """Read the latest state surface (empty dict if none yet). The past-tense read."""
+    target = Path(directory).expanduser() if directory else state_dir()
+    state_path = target / "state.json"
+    try:
+        return json.loads(state_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}

--- a/src/organvm_engine/portal/store.py
+++ b/src/organvm_engine/portal/store.py
@@ -282,6 +282,79 @@ def insert_backflow_signal(
     conn.commit()
 
 
+def get_latest_proposal(conn: sqlite3.Connection, external_repo: str) -> sqlite3.Row | None:
+    """Most recent transmutation proposal for a repo (inbound face)."""
+    try:
+        return conn.execute(
+            "SELECT * FROM transmutation_proposal WHERE external_repo=? "
+            "ORDER BY id DESC LIMIT 1",
+            (external_repo,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+
+
+def set_proposal_status(
+    conn: sqlite3.Connection,
+    proposal_id: int,
+    status: str,
+    *,
+    files: list[str] | None = None,
+    tests: list[str] | None = None,
+) -> None:
+    """Advance a proposal's own status (distinct from the exchange lifecycle state)."""
+    if files is not None or tests is not None:
+        conn.execute(
+            "UPDATE transmutation_proposal SET status=?, files_json=?, tests_json=? "
+            "WHERE id=?",
+            (status, json.dumps(files or []), json.dumps(tests or []), proposal_id),
+        )
+    else:
+        conn.execute(
+            "UPDATE transmutation_proposal SET status=? WHERE id=?", (status, proposal_id),
+        )
+    conn.commit()
+
+
+def get_latest_candidate(conn: sqlite3.Connection, external_repo: str) -> Any | None:
+    """Reconstruct the most recent contribution candidate (outbound face)."""
+    try:
+        row = conn.execute(
+            "SELECT * FROM contribution_candidate WHERE external_repo=? "
+            "ORDER BY id DESC LIMIT 1",
+            (external_repo,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    if row is None:
+        return None
+    from organvm_engine.portal.models import ContributionCandidate
+
+    return ContributionCandidate(
+        exchange_id=row["exchange_id"],
+        external_repo=row["external_repo"],
+        kind=row["kind"],
+        rationale=row["rationale"],
+        contribution_score=row["contribution_score"],
+        status=row["status"],
+        packet=json.loads(row["packet_json"] or "{}"),
+    )
+
+
+def latest_upstream_interaction(
+    conn: sqlite3.Connection, exchange_id: str,
+) -> sqlite3.Row | None:
+    """Most recent upstream interaction for an exchange (the external-write record)."""
+    try:
+        return conn.execute(
+            "SELECT * FROM upstream_interaction WHERE exchange_id=? "
+            "ORDER BY id DESC LIMIT 1",
+            (exchange_id,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+
+
 def counts(conn: sqlite3.Connection) -> dict[str, int]:
     out: dict[str, int] = {}
     for table in ("resonance_edge", "transmutation_proposal", "contribution_candidate",

--- a/tests/test_portal_cli_epic6.py
+++ b/tests/test_portal_cli_epic6.py
@@ -1,0 +1,223 @@
+"""Epic-6 loop-driving CLI verbs: prepare / candidate / package / submit / backflow.
+
+These exercise the exchange lifecycle end to end against a seeded portal store —
+the same code paths ``done.sh`` drives live. The critical assertions are the
+human-gate boundary (A2 refuses; approval reaches HUMAN_APPROVED but opens no PR)
+and the single-``exchange_id`` thread across both faces of one exchange.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from organvm_engine.cli.portal import (
+    cmd_portal_backflow,
+    cmd_portal_candidate,
+    cmd_portal_metabolize,
+    cmd_portal_package,
+    cmd_portal_prepare,
+    cmd_portal_propose,
+    cmd_portal_submit,
+)
+from organvm_engine.portal import store
+from organvm_engine.portal.state_machine import ExchangeState
+
+EXID = "01EXCHANGE0000000000000001"
+REPO = "acme/widget"
+NODE = "MDEwOlJlcG9zaXRvcnkx"
+
+_DOC = {
+    "external_repo": REPO,
+    "snapshot_ref": "abc1234567deadbeefcafe",
+    "identity": {
+        "primary_language": "Python",
+        "languages": {"Python": 1.0},
+        "topics": ["cli", "tools"],
+        "description": "A widget library.",
+    },
+    "state": {"archived": False, "last_push_at": "2026-01-01T00:00:00Z"},
+    "contracts": {
+        "decision": "idea-or-interface-only-unless-obligations-accepted",
+        "license": {"spdx": "MIT"},
+        "contributing": "CONTRIBUTING.md",
+        "cla_or_dco": "dco",
+    },
+    "architecture": {"manifests": ["pyproject.toml"], "test_strategy": ["pytest"]},
+    "provenance": {"hashes": {"README.md": "deadbeef"}},
+}
+
+_DOSSIER_DDL = """
+CREATE TABLE IF NOT EXISTS dossier (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id     TEXT NOT NULL,
+    full_name   TEXT NOT NULL,
+    level       TEXT NOT NULL,
+    doc_json    TEXT NOT NULL,
+    exchange_id TEXT DEFAULT '',
+    UNIQUE(node_id, level)
+)
+"""
+
+
+def _seed(db_path, *, state=ExchangeState.MAPPED):
+    """Seed one exchange + dossier (the alchemia intake, minimally)."""
+    conn = store.connect(str(db_path))
+    store.init_exchange_schema(conn)
+    conn.execute(_DOSSIER_DDL)
+    conn.execute(
+        "INSERT OR IGNORE INTO exchange(exchange_id, external_repo_node_id, "
+        "external_repo, state, created_at, updated_at, data_json) "
+        "VALUES(?,?,?,?,?,?,?)",
+        (EXID, NODE, REPO, state.value, store.now_iso(), store.now_iso(), "{}"),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO dossier(node_id, full_name, level, doc_json, exchange_id) "
+        "VALUES(?,?,?,?,?)",
+        (NODE, REPO, "S1", json.dumps(_DOC), EXID),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _ns(db_path, **kw):
+    return argparse.Namespace(external=REPO, db=str(db_path), **kw)
+
+
+def _exchange_state(db_path):
+    conn = store.connect(str(db_path))
+    row = store.get_exchange(conn, EXID)
+    conn.close()
+    return row["state"]
+
+
+def _count(db_path, table, where=""):
+    conn = store.connect(str(db_path))
+    q = f"SELECT COUNT(*) n FROM {table} {where}"  # noqa: S608 - test-local table names
+    n = conn.execute(q).fetchone()["n"]
+    conn.close()
+    return n
+
+
+def test_prepare_inbound_draft_pr(tmp_path):
+    db = tmp_path / "portal.db"
+    _seed(db)
+    assert cmd_portal_propose(_ns(db, target="organvm-engine")) == 0
+    out_dir = tmp_path / "proposals"
+    assert cmd_portal_prepare(_ns(db, out_dir=str(out_dir))) == 0
+    # Inbound branch walked to INTERNAL_PR_OPEN, artifact written, no default-branch write.
+    assert _exchange_state(db) == ExchangeState.INTERNAL_PR_OPEN.value
+    artifact = out_dir / f"{EXID}.md"
+    assert artifact.exists()
+    body = artifact.read_text()
+    assert "draft internal pr" in body.lower()
+    assert EXID in body
+
+
+def test_candidate_and_package_outbound(tmp_path):
+    db = tmp_path / "portal.db"
+    _seed(db)
+    assert cmd_portal_candidate(
+        _ns(db, kind="documentation-ambiguity", rationale="Ambiguous README setup step",
+            tractability=0.6, testability=0.6),
+    ) == 0
+    assert _count(db, "contribution_candidate") == 1
+    assert _exchange_state(db) == ExchangeState.CONTRIBUTION_CANDIDATE.value
+    # Packaging plans a workspace + checks and stores the packet; nothing is sent.
+    assert cmd_portal_package(_ns(db, ref=None)) == 0
+    assert _exchange_state(db) == ExchangeState.PATCH_PREPARED.value
+    assert _count(db, "upstream_interaction") == 0  # prepared, not submitted
+
+
+def test_candidate_rejects_unknown_kind(tmp_path):
+    db = tmp_path / "portal.db"
+    _seed(db)
+    # Not an evidence-driven kind -> refused.
+    assert cmd_portal_candidate(
+        _ns(db, kind="i-just-like-it", rationale="vibes"),
+    ) == 1
+    assert _count(db, "contribution_candidate") == 0
+
+
+def test_submit_refuses_without_approval(tmp_path):
+    """A2 default: prepare, never submit. The gate must hold."""
+    db = tmp_path / "portal.db"
+    _seed(db)
+    cmd_portal_candidate(_ns(db, kind="documentation-ambiguity", rationale="x"))
+    cmd_portal_package(_ns(db, ref=None))
+    assert cmd_portal_submit(
+        _ns(db, approve=False, checks_passing=False, execute=False),
+    ) == 0
+    # No external-write record; lifecycle never reached UPSTREAM_SUBMITTED.
+    assert _count(db, "upstream_interaction") == 0
+    assert _exchange_state(db) != ExchangeState.UPSTREAM_SUBMITTED.value
+
+
+def test_submit_authorizes_but_does_not_execute(tmp_path):
+    """--approve --checks-passing reaches HUMAN_APPROVED; no --execute => no PR opened."""
+    db = tmp_path / "portal.db"
+    _seed(db)
+    cmd_portal_candidate(_ns(db, kind="documentation-ambiguity", rationale="x"))
+    cmd_portal_package(_ns(db, ref=None))
+    assert cmd_portal_submit(
+        _ns(db, approve=True, checks_passing=True, execute=False),
+    ) == 0
+    assert _exchange_state(db) == ExchangeState.HUMAN_APPROVED.value
+    assert _count(db, "upstream_interaction") == 0  # the external write never happened
+
+
+def test_backflow_completes_and_threads_one_exchange(tmp_path):
+    """The two-faced proof: one exchange_id threads inbound + outbound + backflow."""
+    db = tmp_path / "portal.db"
+    _seed(db)
+    # Inbound face
+    cmd_portal_propose(_ns(db, target="organvm-engine"))
+    cmd_portal_prepare(_ns(db, out_dir=str(tmp_path / "p")))
+    # Outbound face
+    cmd_portal_candidate(_ns(db, kind="documentation-ambiguity", rationale="x"))
+    cmd_portal_package(_ns(db, ref=None))
+    cmd_portal_submit(_ns(db, approve=True, checks_passing=True, execute=False))
+    # Backflow
+    assert cmd_portal_backflow(_ns(db, outcome="dormant", write=False)) == 0
+    assert _exchange_state(db) == ExchangeState.BACKFLOW_COMPLETE.value
+    assert _count(db, "backflow_signal") >= 2  # community + distribution at minimum
+
+    # One exchange_id threads every stage.
+    for table in ("transmutation_proposal", "contribution_candidate", "backflow_signal"):
+        assert _count(db, table, f"WHERE exchange_id='{EXID}'") >= 1
+
+
+def _metabolize_ns(db, tmp_path):
+    return argparse.Namespace(
+        db=str(db), budget=5, threshold=0.15, no_absorb=True,
+        state_dir=str(tmp_path / "state"), out_dir=str(tmp_path / "prop"),
+    )
+
+
+def test_metabolize_bounded_idempotent_and_surfaces(tmp_path):
+    """The autopoietic beat: absorb(skip)->map->prepare(inbound)->surface. Never submits."""
+    db = tmp_path / "portal.db"
+    _seed(db)
+    # A resonance edge so the bounded inbound-prepare JOIN matches this exchange.
+    conn = store.connect(str(db))
+    store.upsert_resonance_edge(
+        conn, exchange_id=EXID, external_node_id=NODE, external_repo=REPO,
+        internal_repo="organvm-engine", lens="technical", score=0.5,
+        evidence=["shared language: python"],
+    )
+    conn.commit()
+    conn.close()
+
+    ns = _metabolize_ns(db, tmp_path)
+    assert cmd_portal_metabolize(ns) == 0
+    # Observable state surface written (organ-health probes this).
+    assert (tmp_path / "state" / "state.json").exists()
+    # Inbound face prepared; exchange moved off MAPPED; nothing sent.
+    assert _count(db, "transmutation_proposal") >= 1
+    assert _count(db, "upstream_interaction") == 0
+    assert _exchange_state(db) != ExchangeState.MAPPED.value
+
+    # Idempotent + bounded: re-run finds nothing at MAPPED, adds no new proposals.
+    before = _count(db, "transmutation_proposal")
+    assert cmd_portal_metabolize(ns) == 0
+    assert _count(db, "transmutation_proposal") == before


### PR DESCRIPTION
Epic-6 closeout + the autopoiesis effector for the **BIFRONS** star↔contribution portal (engine half). The whole-loop modules merged in #166, but the CLI stopped at `portal propose` and nothing ran the loop unbidden.

## Loop-driving verbs (`cli/portal.py`)
- `portal prepare` — inbound: proposal → **draft internal PR** (no default-branch write)
- `portal candidate` / `portal package` — outbound: evidence → candidate → prepared packet (**sends nothing**)
- `portal submit` — the single human-gated external-write boundary (A2 refuses; `--approve --checks-passing` reaches `HUMAN_APPROVED`, opens no PR; only `--execute` shells to `gh`)
- `portal backflow` — seven-organ backflow → `BACKFLOW_COMPLETE`
- `portal metabolize` — **the autopoietic effector**: one bounded, idempotent, fail-open beat (absorb via alchemia if present → `import_stars` → prepare inbound draft PRs for the next N high-resonance `MAPPED` exchanges → write `~/.organvm/bifrons/state.json`). **Never submits.**

## `done.sh` — the acceptance predicate (charter Definition of Done)
Drives one exchange through both faces and asserts: one `exchange_id` threads star→backflow; the A2 gate holds (0 `upstream_interaction`); the metabolize beat surfaces observable state. Deterministic + offline by default; `BIFRONS_LIVE=1` runs the real 419-star intake (verified: 419 synced idempotently).

## Verification
- 30 BIFRONS tests green; whole suite **5374 passed** (4 pre-existing failures in `test_exit_interview_*`/`test_paths.py`, unrelated); `ruff check src/ tests/` + `pyright src/` clean; `bash done.sh` exits 0.

Engine touches no deploy paths. Feeds (does not rebuild) SPECVLVM + `organvm/contrib/LEDGER.yaml` `source: starred`. The one external write (upstream PR) stays the human valve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)